### PR TITLE
Improve `LabeledArray` and documentation

### DIFF
--- a/docs/src/man/date-and-time-values.md
+++ b/docs/src/man/date-and-time-values.md
@@ -18,7 +18,7 @@ The full lists of recognized date/time formats for the statistical software
 are stored as dictionary keys;
 while the associated values are tuples of reference date/time and period length.[^2]
 If a variable is in a date/time format that is contained in the dictionary keys,
-[`readstat`](@ref) will handle the conversion into a Julia time type
+[`readstat`](@ref) will handle the conversion to a Julia time type
 (unless the `convert_datetime` option prevents it).
 Otherwise, if a date/time format is not found in the dictionary keys,
 no type conversion will be attempted.

--- a/docs/src/man/getting-started.md
+++ b/docs/src/man/getting-started.md
@@ -95,55 +95,55 @@ Variables with value labels are stored in [`LabeledArray`](@ref)s.
 To convert a `LabeledArray` to another array type,
 we may either obtain an array of [`LabeledValue`](@ref)s
 or collect the values and labels separately.
-If only the labels contain the relevant information,
-we can make use of the `labels` function which returns an iterator for the labels.
-For example, to convert a `LabeledArray` to a `CategoricalArray` from
-[CategoricalArrays.jl](https://github.com/JuliaData/CategoricalArrays.jl):
-
-```@repl getting-started
-using CategoricalArrays
-CategoricalArray(labels(tb.mylabl))
-```
-
-Sometimes, the values have special meanings while the labels are not so important.
-To access the array of values underlying a `LabeledArray` directly:
+The data values can be directly retrieved by calling [`refarray`](@ref):
 
 ```@repl getting-started
 refarray(tb.mylabl)
 ```
 
-Alternatively, convert a `LabeledArray` to an array with appropriate element type:
-
-```@repl getting-started
-convert(Vector{Int}, tb.mylabl)
-```
-
-In the last example, the element type of the output array has become `Int`
-while the labels are ignored.
-
 !!! note
 
-    The array returned by `refarray` (and by `convert` if element type is not converted)
+    The array returned by `refarray`
     is exactly the same array underlying the `LabeledArray`.
     Therefore, modifying the elements of the array
     will also mutate the values in the associated `LabeledArray`.
 
+If only the value labels are needed,
+we can obtain an iterator of the value labels via [`valuelabels`](@ref).
+For example, to convert a `LabeledArray` to a `CategoricalArray` from
+[CategoricalArrays.jl](https://github.com/JuliaData/CategoricalArrays.jl):
+
+```@repl getting-started
+using CategoricalArrays
+CategoricalArray(valuelabels(tb.mylabl))
+```
+
+It is also possible to only convert the type of the underlying data values:
+
+```@repl getting-started
+convertvalue(Int32, tb.mylabl)
+```
+
+```@docs
+convertvalue
+```
+
 ## More Options
 
-The behavior of `readstat` can be adjusted by passing keyword arguments.
+The behavior of `readstat` can be adjusted by passing keyword arguments:
 
 ```@docs
 readstat
 ```
 
-The accepted values for selecting certain variables (columns) are shown below:
+The accepted types of values for selecting certain variables (data columns) are shown below:
 
 ```@docs
 ReadStatTables.ColumnIndex
 ReadStatTables.ColumnSelector
 ```
 
-File-level metadata can be obtained without reading the entire data file.
+File-level metadata can be obtained without reading the entire data file:
 
 ```@docs
 readstatmeta

--- a/docs/src/man/metadata.md
+++ b/docs/src/man/metadata.md
@@ -100,7 +100,7 @@ m["label"]
 copy(m)
 ```
 
-However, it can not be modified directly via `setindex!`:
+However, it cannot be modified directly via `setindex!`:
 
 ```@repl meta
 m["label"] = "A new label"

--- a/docs/src/man/table-interface.md
+++ b/docs/src/man/table-interface.md
@@ -1,6 +1,6 @@
 # Table Interface
 
-This page provides further details on the interface of `ReadStatTable`.
+This page provides further details on the interface of [`ReadStatTable`](@ref).
 
 ```@docs
 ReadStatTable
@@ -59,7 +59,7 @@ end
 ## Data Values
 
 In addition to retrieving the data columns,
-it is possible to directly retrieving and modifying individual data values
+it is possible to directly retrieve and modify individual data values
 via `getindex` and `setindex!`.
 
 ```@repl table

--- a/docs/src/man/value-labels.md
+++ b/docs/src/man/value-labels.md
@@ -1,23 +1,43 @@
 # Value Labels
 
-Value labels from the data files are incorporated into the data columns
-via a customized array type `LabeledArray`.
+Value labels collected from the data files are incorporated into the associated data columns
+via a customized array type [`LabeledArray`](@ref).
 
 ## LabeledValue and LabeledArray
 
 `LabeledValue` and `LabeledArray` are designed to
 imitate how variables associated with value labels
 are represented in the original data files from the statistical software.
+The former wraps a data array with a reference to the value labels;
+while the latter wraps a single data value.
 The element of a `LabeledArray` is always a `LabeledValue`.
+However, a `LabeledValue` obtained from a `LabeledArray`
+is only constructed when being retrieved via `getindex` for efficient storage.
 
-In general, variables associated with value labels
-should not be treated as categorical data.
-Here are some noteworthy distinctions of `LabeledArray` from
-an array type designed for categorical data (e.g., `CategoricalArray`):
+Some noteworthy distinctions of a `LabeledArray` are highlighted below:
 
-- Values are never recoded when a `LabeledArray` is constructed.[^1]
-- It is allowed for some values in a `LabeledArray` to not have a label.[^2]
+- Values are never re-encoded when a `LabeledArray` is constructed.[^1]
+- It is allowed for some values in a `LabeledArray` to not have a value label.[^2]
 - A label is always a `String` even when it is associated with `missing`.
+
+In essence, a `LabeledArray` is simply an array of data values (typically numbers)
+bundled with a dictionary of value labels.
+There is no restriction imposed on the correspondence
+between the data values and value labels.
+Namely, a data value in a `LabeledArray` is not necessarily attached with a value label
+from the associated dictionary;
+while the key of a value label contained in the dictionary
+may not match any array element.
+Furthermore, the dictionary of value labels may be switched and shared
+across different `LabeledArray`s.
+When setting values in a `LabeledArray`,
+the array of data values are modified directly
+with no additional check on the associated dictionary of value labels.
+For this reason, the functionality of a `LabeledArray`
+is not equivalent to that of an array type designed for categorical data
+(e.g., `CategoricalArray` from
+[CategoricalArrays.jl](https://github.com/JuliaData/CategoricalArrays.jl)).
+They are not complete substitutes for each other.
 
 More details are below.
 
@@ -25,23 +45,23 @@ More details are below.
 LabeledValue
 LabeledArray
 LabeledVector
+LabeledMatrix
 ```
 
-## Accessing Labels and Values
+## Accessing Values and Labels
 
-If only the labels of a `LabeledArray` are needed,
-an iterator that maintains the shape of the `LabeledArray`
-can be obtained by calling `labels`.
-The iterator can be used for either collecting all labels in a different array type
-or retrieving labels for specific values.
-On the other hand, if only the values are needed,
-the labels can be ignored
-if one directly accesses the underlying array that holds the values.
+For `LabeledValue`, the underlying data value can be retrieved via [`unwrap`](@ref).
+The value label can be obtained via [`valuelabel`](@ref) or conversion to `String`.
+For `LabeledArray`, the underlying data values can be retrieved via [`refarray`](@ref).
+An iterator of value labels that maintains the shape of the `LabeledArray`
+can be obtained by calling [`valuelabels`](@ref).
 
 ```@docs
-labels
 unwrap
+valuelabel
+getvaluelabels
 refarray
+valuelabels
 ```
 
 [^1]:

--- a/src/LabeledArrays.jl
+++ b/src/LabeledArrays.jl
@@ -337,7 +337,7 @@ Base.convert(::Type{<:AbstractArray{<:LabeledValue{T},N}},
     convertvalue(T, x::LabeledArray)
 
 Convert the type of data values contained in `x` to `T`.
-This method is equivalent to `convert(AbstractArray{LabeledValue{T,K},N}}, x)`.
+This method is equivalent to `convert(AbstractArray{LabeledValue{T, K}, N}}, x)`.
 """
 convertvalue(::Type{T}, x::LabeledArray{V,N}) where {T,V,N} =
     LabeledArray(convert(AbstractArray{T,N}, refarray(x)), getvaluelabels(x))

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -22,7 +22,11 @@ export columnnames
 export LabeledValue,
        LabeledArray,
        LabeledVector,
-       labels,
+       LabeledMatrix,
+       valuelabel,
+       getvaluelabels,
+       convertvalue,
+       valuelabels,
 
        ReadStatColumns,
 
@@ -37,8 +41,7 @@ export LabeledValue,
        colmetavalues,
 
        readstat,
-       readstatmeta,
-       valuelabels
+       readstatmeta
 
 include("wrappers.jl")
 include("LabeledArrays.jl")

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -66,7 +66,7 @@ const dt_formats = Dict{String, Dict}(
 Construct a vector of time values of type `DateTime` or `Date`
 by interpreting the elements in `col` as the number of periods passed
 since `epoch` with the length of each period being `delta`.
-Returned object is of a type acceptable by [`ReadStatColumns`](@ref).
+Returned object is of a type acceptable by `ReadStatColumns`.
 """
 function parse_datetime(col::AbstractVector, epoch::Union{DateTime,Date}, delta::Period,
         hasmissing::Bool)

--- a/src/table.jl
+++ b/src/table.jl
@@ -89,7 +89,7 @@ a data column processed with `ReadStat`.
 
 Metadata can be retrieved and modified from the associated [`ReadStatTable`](@ref)
 via methods compatible with `DataAPI.jl`.
-A dictionary-like interface is also available for directly working with `ReadStatColMeta`
+A dictionary-like interface is also available for directly working with `ReadStatColMeta`,
 but it does not allow modifying metadata values.
 An alternative way to retrive and modify the metadata is via [`colmetavalues`](@ref).
 
@@ -97,7 +97,7 @@ An alternative way to retrive and modify the metadata is via [`colmetavalues`](@
 - `label::String`: variable label.
 - `format::String`: variable format.
 - `type::readstat_type_t`: original variable type recognized by `ReadStat`.
-- `vallabel::Symbol`: name of the dictionary of value labels associated with the variable; see also [`getvaluelabels`](@ref).
+- `vallabel::Symbol`: name of the dictionary of value labels associated with the variable; see also [`getvaluelabels`](@ref) for the effect of modifying this field.
 - `storage_width::Csize_t`: variable storage width in data file.
 - `display_width::Cint`: width for display.
 - `measure::readstat_measure_t`: measure type of the variable; only relevant to SPSS.

--- a/src/table.jl
+++ b/src/table.jl
@@ -160,7 +160,7 @@ const ColMetaVec = StructVector{ReadStatColMeta, NamedTuple{(:label, :format, :t
 
 A `Tables.jl`-compatible column table that efficiently collects data
 from a Stata, SAS or SPSS file processed with the `ReadStat` C library.
-File-level and column-level metadata can be retrieved and modified
+File-level and variable-level metadata can be retrieved and modified
 via methods compatible with `DataAPI.jl`.
 
 See also [`ReadStatMeta`](@ref) and [`ReadStatColMeta`](@ref) for the included metadata.
@@ -452,7 +452,7 @@ obtained from the data file.
 Return a specific dictionary of value labels if a `name` is specified.
 
 Each dictionary of value labels is associated with a name
-that may appear in the column-level metadata under the key `vallabel`
+that may appear in the variable-level metadata under the key `vallabel`
 for identifying the dictionary of value labels attached to each data column.
 The same dictionary may be associated with multiple data columns.
 Modifying the metadata value of `vallabel` for a data column

--- a/src/table.jl
+++ b/src/table.jl
@@ -21,11 +21,12 @@ Base.get(f::Base.Callable, m::AbstractMetaDict, key) =
 
 A collection of file-level metadata associated with a data file processed with `ReadStat`.
 
-Metadata can be retrieved and modified either through
-a dictionary-like interface or via methods compatible with `DataAPI.jl`.
+Metadata can be retrieved and modified from the associated [`ReadStatTable`](@ref)
+via methods compatible with `DataAPI.jl`.
+A dictionary-like interface is also available for directly working with `ReadStatMeta`.
 
 # Fields
-- `row_count::Int`: number of rows returned by `ReadStat` parser; being `-1` if not available in metadata; may reflect the value set with the `row_limit` parser option.
+- `row_count::Int`: number of rows returned by `ReadStat` parser; being `-1` if not available in metadata; may reflect the value set with the `row_limit` parser option instead of the actual number of rows in the data file.
 - `var_count::Int`: number of data columns returned by `ReadStat` parser.
 - `creation_time::DateTime`: timestamp for file creation.
 - `modified_time::DateTime`: timestamp for file modification.
@@ -86,15 +87,17 @@ end
 A collection of variable-level metadata associated with
 a data column processed with `ReadStat`.
 
-Metadata can be retrieved and modified via methods compatible with `DataAPI.jl`.
-A dictionary-like interface only allows retrieving the metadata.
+Metadata can be retrieved and modified from the associated [`ReadStatTable`](@ref)
+via methods compatible with `DataAPI.jl`.
+A dictionary-like interface is also available for directly working with `ReadStatColMeta`
+but it does not allow modifying metadata values.
 An alternative way to retrive and modify the metadata is via [`colmetavalues`](@ref).
 
 # Fields
 - `label::String`: variable label.
 - `format::String`: variable format.
 - `type::readstat_type_t`: original variable type recognized by `ReadStat`.
-- `vallabel::Symbol`: name of the set of value labels associated with the variable.
+- `vallabel::Symbol`: name of the dictionary of value labels associated with the variable; see also [`getvaluelabels`](@ref).
 - `storage_width::Csize_t`: variable storage width in data file.
 - `display_width::Cint`: width for display.
 - `measure::readstat_measure_t`: measure type of the variable; only relevant to SPSS.
@@ -155,14 +158,18 @@ const ColMetaVec = StructVector{ReadStatColMeta, NamedTuple{(:label, :format, :t
 """
     ReadStatTable <: Tables.AbstractColumns
 
-A `Tables.jl`-compatible column table that collects data (including metadata)
-for a Stata, SAS or SPSS file processed with `ReadStat`.
+A `Tables.jl`-compatible column table that efficiently collects data
+from a Stata, SAS or SPSS file processed with the `ReadStat` C library.
+File-level and column-level metadata can be retrieved and modified
+via methods compatible with `DataAPI.jl`.
+
+See also [`ReadStatMeta`](@ref) and [`ReadStatColMeta`](@ref) for the included metadata.
 """
 struct ReadStatTable <: Tables.AbstractColumns
     columns::ReadStatColumns
     names::Vector{Symbol}
     lookup::Dict{Symbol, Int}
-    vallabels::Dict{Symbol, Dict{Any,String}}
+    vallabels::Dict{Symbol, Dict}
     hasmissing::Vector{Bool}
     meta::ReadStatMeta
     colmeta::ColMetaVec
@@ -171,7 +178,7 @@ struct ReadStatTable <: Tables.AbstractColumns
         columns = ReadStatColumns()
         names = Symbol[]
         lookup = Dict{Symbol, Int}()
-        vallabels = Dict{Symbol, Dict{Any,String}}()
+        vallabels = Dict{Symbol, Dict}()
         hasmissing = Vector{Bool}()
         meta = ReadStatMeta()
         colmeta = StructVector{ReadStatColMeta}((String[], String[], readstat_type_t[],
@@ -180,7 +187,7 @@ struct ReadStatTable <: Tables.AbstractColumns
         return new(columns, names, lookup, vallabels, hasmissing, meta, colmeta, styles)
     end
     function ReadStatTable(columns::ReadStatColumns, names::Vector{Symbol},
-            vallabels::Dict{Symbol, Dict{Any,String}}, hasmissing::Vector{Bool},
+            vallabels::Dict{Symbol, Dict}, hasmissing::Vector{Bool},
             meta::ReadStatMeta, colmeta::ColMetaVec,
             styles::Dict{Symbol, Symbol}=Dict{Symbol, Symbol}())
         lookup = Dict{Symbol, Int}(n=>i for (i, n) in enumerate(names))
@@ -269,8 +276,8 @@ function _gettype(tb::ReadStatTable, i)
     T = eltype(Tables.getcolumn(tb, i))
     if T === Union{Int8, Missing}
         _hasmissing(tb)[i] || return Int8
-    elseif T === LabeledValue{Union{Missing, Int8}}
-        _hasmissing(tb)[i] || return LabeledValue{Int8}
+    elseif T <: LabeledValue && T.parameters[1] === Union{Int8, Missing}
+        _hasmissing(tb)[i] || return LabeledValue{Int8, T.parameters[2]}
     end
     return T
 end
@@ -436,5 +443,22 @@ Return an array of metadata values associated with `key` for all columns in `tb`
 """
 colmetavalues(tb::ReadStatTable, key) = _colmeta(tb, key)
 
-valuelabels(tb::ReadStatTable) = _vallabels(tb)
-valuelabels(tb::ReadStatTable, name::Symbol) = _vallabels(tb)[name]
+"""
+    getvaluelabels(tb::ReadStatTable)
+    getvaluelabels(tb::ReadStatTable, name::Symbol)
+
+Return a dictionary of all value label dictionaries contained in `tb`
+obtained from the data file.
+Return a specific dictionary of value labels if a `name` is specified.
+
+Each dictionary of value labels is associated with a name
+that may appear in the column-level metadata under the key `vallabel`
+for identifying the dictionary of value labels attached to each data column.
+The same dictionary may be associated with multiple data columns.
+Modifying the metadata value of `vallabel` for a data column
+switches the associated value labels for the data column.
+If the metadata value is set to `Symbol("")`,
+the data column is not associated with any value label.
+"""
+getvaluelabels(tb::ReadStatTable) = _vallabels(tb)
+getvaluelabels(tb::ReadStatTable, name::Symbol) = _vallabels(tb)[name]

--- a/test/LabeledArrays.jl
+++ b/test/LabeledArrays.jl
@@ -95,6 +95,7 @@ end
     @test s.labels === lbls
 
     @test view(x, 1:3)[Int16(1)] === LabeledValue(1, lbls)
+    @test reshape(x, 2, 3)[Int16(1)] === LabeledValue(1, lbls)
     v = view(x, 1:3)[1:2]
     @test v isa LabeledArray
     @test v.labels === lbls
@@ -105,6 +106,8 @@ end
     @test v isa LabeledArray
     @test v.labels === lbls
 
+    @test view(x2, 1:2, 1:2)[Int16(1)] === LabeledValue(1, lbls)
+    @test reshape(x2, 2, 3)[Int16(1)] === LabeledValue(1, lbls)
     v = view(x2, 1:2, 1:2)[1,1]
     @test v isa LabeledValue
     @test v.labels === lbls

--- a/test/LabeledArrays.jl
+++ b/test/LabeledArrays.jl
@@ -1,5 +1,5 @@
 @testset "LabeledValue" begin
-    lbls1 = Dict{Any,String}(1=>"a", 2=>"b")
+    lbls1 = Dict{Int32,String}(1=>"a", 2=>"b")
     lbls2 = Dict{Any,String}(1.0=>"b")
     v1 = LabeledValue(1, lbls1)
     v2 = LabeledValue(2, lbls1)
@@ -16,8 +16,6 @@
 
     @test v1 == 1
     @test 1 == v1
-    @test v1 == "a"
-    @test "a" == v1
     @test ismissing(v1 == missing)
     @test ismissing(missing == v1)
     @test isequal(v1, 1)
@@ -40,58 +38,131 @@
     @test haskey(d, v3)
 
     @test unwrap(v1) === 1
-    @test labels(v1) == "a"
-    @test labels(v4) == "missing"
+    @test valuelabel(v1) == "a"
+    @test valuelabel(v4) == "missing"
+    @test getvaluelabels(v1) === v1.labels
 
     @test sprint(show, v1) == "a"
     @test sprint(show, v4) == "missing"
     @test sprint(show, MIME("text/plain"), v1) == "1 => a"
 
+    v5 = convert(LabeledValue{Int16}, v1)
+    @test v5.value isa Int16
+    @test v5.labels === v1.labels
     @test convert(String, v1) == "a"
 end
 
 @testset "LabeledArray" begin
     vals = repeat(1:3, inner=2)
-    lbls = Dict{Any,String}(i=>string(i) for i in 1:3)
+    lbls = Dict{Union{Int,Missing},String}(i=>string(i) for i in 1:3)
     x = LabeledArray(vals, lbls)
-    @test eltype(x) == LabeledValue{Int}
+    @test eltype(x) == LabeledValue{Int, Union{Int,Missing}}
     @test size(x) == (6,)
-    @test IndexStyle(typeof(x)) == IndexLinear()
+    @test IndexStyle(typeof(x)) == IndexStyle(typeof(vals))
 
     @test x[1] === LabeledValue(1, lbls)
-    @test x[2:3] == [1, 2]
-    @test x[isodd.(1:6)] == [1, 2, 3]
-    @test_throws ArgumentError LabeledArray(string.(vals), Dict{Any,String}())
+    @test x[Int16(1)] === LabeledValue(1, lbls)
+    s = x[2:3]
+    @test s == [1, 2]
+    @test s isa LabeledArray
+    @test s.labels === lbls
+    s = x[isodd.(1:6)]
+    @test s == [1, 2, 3]
+    @test s isa LabeledArray
+    @test s.labels === lbls
+
+    x2 = LabeledArray([1:3 1:3], lbls)
+    ra = refarray(x2)
+    @test size(ra) == (3, 2)
+    @test ra isa Matrix{Int64}
+
+    @test x2[1] === LabeledValue(1, lbls)
+    @test x2[1,1] === LabeledValue(1, lbls)
+    s = x2[2:3]
+    @test s == [2, 3]
+    @test s isa LabeledArray
+    @test s.labels === lbls
+    s = x2[isodd.(1:6)]
+    @test s == [1, 3, 2]
+    @test s isa LabeledArray
+    @test s.labels === lbls
+    s = x2[1,1:2]
+    @test s == [1, 1]
+    @test s isa LabeledArray
+    @test s.labels === lbls
+    s = x2[2,isodd.(1:2)]
+    @test s isa LabeledArray
+    @test s.labels === lbls
+
+    v = view(x, 1:3)[1:2]
+    @test v isa LabeledArray
+    @test v.labels === lbls
+    v = reshape(x, 3, 2)[1:2]
+    @test v isa LabeledArray
+    @test v.labels === lbls
+    v = view(x2, 1:3)[1:2]
+    @test v isa LabeledArray
+    @test v.labels === lbls
+
+    v = view(x2, 1:2, 1:2)[1,1]
+    @test v isa LabeledValue
+    @test v.labels === lbls
+    v = view(x2, 1:2, 1:2)[Int16(1),Int16(1)]
+    @test v isa LabeledValue
+    @test v.labels === lbls
+    v = view(x2, 1:2, 1:2)[1,1:2]
+    @test v isa LabeledArray
+    @test v.labels === lbls
+
+    x[1] = 2
+    @test x[1] == 2
+    x[1:2] .= 1
+    @test all(x[1:2] .== 1)
+    x2[1,1:2] .= 2
+    @test all(x2[1,1:2] .== 2)
 
     vals1 = [1, 2, missing]
     x1 = LabeledArray(vals1, lbls)
     @test isequal(x1[3], missing)
-    @test x1[3] == "missing"
+    @test isequal(x1[3], LabeledValue(missing, Dict{Any,String}()))
 
     @test refarray(x) === x.values
     @test refarray(view(x, [1, 3])) == 1:2
     @test refarray(reshape(x, 3, 2)) == reshape(x.values, 3, 2)
-    @test collect(x) == x
+    @test refarray(view(x2, 1:3)) == x2.values[1:3]
+    x3 = collect(x)
+    @test x3 == x
+    @test x3 isa Array
+    @test eltype(x3) == eltype(x)
 
-    x2 = LabeledArray([1:3 1:3], lbls)
-    ra = refarray(collect(x2))
-    @test size(ra) == (3, 2)
-    @test ra isa Matrix{Int64}
+    x3 = LabeledArray(copy(vals1), lbls)
+    fill!(x3, 1)
+    @test all(x3 .== 1)
 
-    lbs = labels(x)
-    @test size(lbs) == size(x)
-    @test IndexStyle(typeof(lbs)) == IndexLinear()
-    @test lbs[1] == "1"
-    @test eltype(typeof(lbs)) == String
-    @test length(lbs) == length(x)
-
-    v = view(x, 1:3)
-    lbs = labels(v)
-    @test size(lbs) == size(v)
-    @test lbs[3] == "2"
-
-    lbs1 = labels(x1)
-    @test lbs1[3] == "missing"
+    v = copy(x)
+    @test v == x
+    @test refarray(v) !== refarray(x)
+    @test v.labels === x.labels
+    resize!(v, 7)
+    @test length(v) == 7
+    push!(v, 1)
+    @test v[8] == 1
+    pushfirst!(v, 2)
+    @test v[1] == 2
+    insert!(v, 3, 4)
+    @test v[3] == 4
+    deleteat!(v, 3)
+    @test length(v) == 9
+    @test v[3] == 1
+    append!(v, 1:3)
+    @test length(v) == 12
+    @test v[10:12] == 1:3
+    prepend!(v, 1:3)
+    @test length(v) == 15
+    @test v[1:3] == 1:3
+    empty!(v)
+    @test isempty(v)
+    sizehint!(v, 10)
 
     y = LabeledArray(copy(vals), copy(lbls))
     @test x == y
@@ -102,15 +173,51 @@ end
 
     @test x == vals
     @test vals == x
-    @test x == string.(vals)
-    @test string.(vals) == x
 
-    @test copy(x) == x
-    @test typeof(copy(x)) == typeof(x)
+    x1 = copy(x)
+    @test x1 == x
+    @test refarray(x1) !== refarray(x)
+    @test typeof(x1) == typeof(x)
+    @test x1.labels === x.labels
 
-    @test convert(Vector{Int}, x) === x.values
-    @test convert(Vector{Int16}, x) == x.values
+    x2 = convert(AbstractVector{LabeledValue{Int16,Union{Int,Missing}}}, x)
+    @test typeof(x2) == LabeledVector{Int16, Vector{Int16}, Union{Int,Missing}}
+    @test x2.values == x.values
+    @test x2.labels === x.labels
 
-    c = CategoricalArray(labels(x))
+    @test convert(AbstractVector{LabeledValue{Int,Union{Int,Missing}}}, x) === x
+
+    x3 = convertvalue(Int16, x)
+    @test typeof(x3) == LabeledVector{Int16, Vector{Int16}, Union{Int,Missing}}
+    @test x3.values == x.values
+    @test x3.labels === x.labels
+
+    s = similar(x)
+    @test typeof(s) == typeof(x)
+    s = similar(x, LabeledValue{Int16})
+    @test eltype(s) == LabeledValue{Int16, keytype(lbls)}
+    s = similar(x, 3, 3)
+    @test size(s) == (3, 3)
+    s = similar(x, LabeledValue{Int16}, 3, 3)
+    @test eltype(s) == LabeledValue{Int16, keytype(lbls)}
+    @test size(s) == (3, 3)
+
+    lbs = valuelabels(x)
+    @test size(lbs) == size(x)
+    @test IndexStyle(typeof(lbs)) == IndexLinear()
+    @test lbs[1] == "1"
+    @test eltype(typeof(lbs)) == String
+    @test length(lbs) == length(x)
+
+    v = view(x, 1:3)
+    lbs = valuelabels(v)
+    @test size(lbs) == size(v)
+    @test lbs[3] == "2"
+
+    x1 = LabeledArray(vals1, lbls)
+    lbs1 = valuelabels(x1)
+    @test lbs1[3] == "missing"
+
+    c = CategoricalArray(valuelabels(x))
     @test c == string.(vals)
 end

--- a/test/LabeledArrays.jl
+++ b/test/LabeledArrays.jl
@@ -94,6 +94,7 @@ end
     @test s isa LabeledArray
     @test s.labels === lbls
 
+    @test view(x, 1:3)[Int16(1)] === LabeledValue(1, lbls)
     v = view(x, 1:3)[1:2]
     @test v isa LabeledArray
     @test v.labels === lbls
@@ -196,7 +197,7 @@ end
     @test typeof(s) == typeof(x)
     s = similar(x, LabeledValue{Int16})
     @test eltype(s) == LabeledValue{Int16, keytype(lbls)}
-    s = similar(x, 3, 3)
+    s = similar(x, (3, 3))
     @test size(s) == (3, 3)
     s = similar(x, LabeledValue{Int16}, 3, 3)
     @test eltype(s) == LabeledValue{Int16, keytype(lbls)}

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -130,11 +130,11 @@ end
 
     alltypes = "$(@__DIR__)/../data/alltypes.dta"
     dtype = readstat(alltypes)
-    @test eltype(dtype[1]) == LabeledValue{Union{Missing, Int8}}
-    @test eltype(dtype[2]) == LabeledValue{Union{Missing, Int16}}
-    @test eltype(dtype[3]) == LabeledValue{Union{Missing, Int32}}
-    @test eltype(dtype[4]) == LabeledValue{Union{Missing, Float32}}
-    @test eltype(dtype[5]) == LabeledValue{Union{Missing, Float64}}
+    @test eltype(dtype[1]) == LabeledValue{Union{Missing, Int8}, Union{Int32,Char}}
+    @test eltype(dtype[2]) == LabeledValue{Union{Missing, Int16}, Union{Int32,Char}}
+    @test eltype(dtype[3]) == LabeledValue{Union{Missing, Int32}, Union{Int32,Char}}
+    @test eltype(dtype[4]) == LabeledValue{Union{Missing, Float32}, Union{Int32,Char}}
+    @test eltype(dtype[5]) == LabeledValue{Union{Missing, Float64}, Union{Int32,Char}}
     @test eltype(dtype[6]) == String
     @test eltype(dtype[7]) == String
     @test length(dtype[1,7]) == 114

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -20,7 +20,7 @@ end
            5 │      e   1000.3     missing              missing           Male         missing  2000-01-01T00:00:00"""
 
     m = metadata(d)
-    @test valuelabels(d, :mylabl) == d.mylabl.labels
+    @test getvaluelabels(d, :mylabl) == d.mylabl.labels
     @test minute(m.modified_time) == 36
     @test sprint(show, m) == "ReadStatMeta(A test file, .dta)"
     # Timestamp displays different values depending on time zone
@@ -74,7 +74,7 @@ end
     d = readstat(dta, usecols=Int[])
     @test sprint(show, d) == "0×0 ReadStatTable"
     @test isempty(colmetadata(d))
-    @test length(valuelabels(d)) == 2
+    @test length(getvaluelabels(d)) == 2
 
     d = readstat(dta, usecols=1:3, row_offset=10)
     @test size(d) == (0, 3)
@@ -138,7 +138,7 @@ end
     @test eltype(dtype[6]) == String
     @test eltype(dtype[7]) == String
     @test length(dtype[1,7]) == 114
-    vallbls = valuelabels(dtype)
+    vallbls = getvaluelabels(dtype)
     @test length(vallbls) == 1
     lbls = vallbls[:testlbl]
     @test length(lbls) == 2

--- a/test/table.jl
+++ b/test/table.jl
@@ -86,8 +86,8 @@ end
     @test size(tb) == (0, 1)
     @test length(tb) == 1
     @test isempty(tb)
-    @test valuelabels(tb) === vls
-    @test valuelabels(tb, :A) === lbls
+    @test getvaluelabels(tb) === vls
+    @test getvaluelabels(tb, :A) === lbls
     delete!(vls, :A)
     @test sprint(show, MIME("text/plain"), tb) == "0×1 ReadStatTable"
 

--- a/test/table.jl
+++ b/test/table.jl
@@ -75,7 +75,7 @@ end
     m = gettestmeta()
     ms = StructVector(ReadStatColMeta[])
     lbls = Dict{Any,String}()
-    vls = Dict{Symbol, Dict{Any,String}}(:A=>lbls)
+    vls = Dict{Symbol, Dict}(:A=>lbls)
     hms = Bool[false]
     @test_throws ArgumentError ReadStatTable(ReadStatColumns(), Symbol[:c], vls, hms, m, ms)
     @test_throws ArgumentError ReadStatTable(ReadStatColumns(), Symbol[], vls, [true], m, ms)
@@ -184,7 +184,7 @@ end
     push!(cols, c1, c2)
     names = [:c1, :c2]
     hms = Bool[false, true]
-    vls = Dict{Symbol, Dict{Any,String}}()
+    vls = Dict{Symbol, Dict}()
     m = gettestmeta()
     ms = StructVector{ReadStatColMeta}((["v1","v2"], ["%tf","%tc"],
         [READSTAT_TYPE_INT8, READSTAT_TYPE_DOUBLE], [:A,Symbol()], [Csize_t(1),Csize_t(1)],


### PR DESCRIPTION
The changes are mostly on `LabeledValue` and `LabeledArray`:

1. The violation of transitivity of `==` discussed [here](https://github.com/junyuan-chen/ReadStatTables.jl/issues/4) has been fixed by removing methods that allow direct comparisons with `String`s.
2. The element type of data array and the key type of the value label dictionary are allowed to be different.
3. More methods on indexing and array operations are added for `LabeledArray`.
4. Phrasing of value labels is more careful to avoid confusion with variable labels. The method `labels` is renamed to `valuelabels` as the former will refer to variable labels, in anticipation of the future release of [TableMetadataTools.jl](https://github.com/JuliaData/TableMetadataTools.jl).