### PR TITLE
Add missing methods of `similar`, `copyto!` and `collect` for `LabeledArray`

### DIFF
--- a/src/LabeledArrays.jl
+++ b/src/LabeledArrays.jl
@@ -325,27 +325,6 @@ Base.:(==)(x::LabeledArray, y::LabeledArray) = refarray(x) == refarray(y)
 Base.:(==)(x::LabeledArray, y::AbstractArray) = refarray(x) == y
 Base.:(==)(x::AbstractArray, y::LabeledArray) = x == refarray(y)
 
-# Value labels are not copied and may still be shared with other LabeledArrays
-Base.copy(x::LabeledArray) = LabeledArray(copy(refarray(x)), getvaluelabels(x))
-
-Base.copyto!(dest::AbstractArray, src::LabeledArrOrSubOrReshape) =
-    copyto!(dest, refarray(src))
-
-Base.copyto!(deststyle::IndexStyle, dest::AbstractArray, srcstyle::IndexStyle,
-    src::LabeledArrOrSubOrReshape) =
-        copyto!(deststyle, dest, srcstyle, refarray(src))
-
-Base.copyto!(dest::AbstractArray, dstart::Integer, src::LabeledArrOrSubOrReshape,
-    sstart::Integer, n::Integer) =
-        copyto!(dest, dstart, refarray(src), sstart, n)
-
-Base.copyto!(B::AbstractVecOrMat, ir_dest::AbstractRange{Int},
-    jr_dest::AbstractRange{Int}, A::LabeledArrOrSubOrReshape,
-    ir_src::AbstractRange{Int}, jr_src::AbstractRange{Int}) =
-        copyto!(B, ir_dest, jr_dest, refarray(A), ir_src, jr_src)
-
-Base.collect(x::LabeledArrOrSubOrReshape) = map(i->@inbounds(getindex(x, i)), eachindex(x))
-
 # Only convert the value type
 Base.convert(::Type{<:AbstractArray{<:LabeledValue{T},N}},
     x::LabeledArray{V,N}) where {T,V,N} =
@@ -371,6 +350,32 @@ Base.similar(x::LabeledArrOrSubOrReshape, ::Type{<:LabeledValue{V}}, dims::Dims)
 Base.similar(x::LabeledArrOrSubOrReshape,
     ::Type{Union{LabeledValue{V, K}, Missing}}, dims::Dims) where {V,K} =
         LabeledArray(similar(refarray(x), Union{V, Missing}, dims), getvaluelabels(x))
+
+# Value labels are not copied and may still be shared with other LabeledArrays
+Base.copy(x::LabeledArray) = LabeledArray(copy(refarray(x)), getvaluelabels(x))
+
+Base.copyto!(dest::AbstractArray, src::LabeledArrOrSubOrReshape) =
+    copyto!(dest, refarray(src))
+
+Base.copyto!(deststyle::IndexStyle, dest::AbstractArray, srcstyle::IndexStyle,
+    src::LabeledArrOrSubOrReshape) =
+        copyto!(deststyle, dest, srcstyle, refarray(src))
+
+Base.copyto!(dest::AbstractArray, dstart::Integer, src::LabeledArrOrSubOrReshape,
+    sstart::Integer, n::Integer) =
+        copyto!(dest, dstart, refarray(src), sstart, n)
+
+Base.copyto!(B::AbstractVecOrMat, ir_dest::AbstractRange{Int},
+    jr_dest::AbstractRange{Int}, A::LabeledArrOrSubOrReshape,
+    ir_src::AbstractRange{Int}, jr_src::AbstractRange{Int}) =
+        copyto!(B, ir_dest, jr_dest, refarray(A), ir_src, jr_src)
+
+# Behavior of collect is nonstandard as LabeledArray instead of Array is returned
+Base.collect(x::LabeledArrOrSubOrReshape) =
+    LabeledArray(collect(refarray(x)), getvaluelabels(x))
+
+Base.collect(::Type{<:LabeledValue{T}}, x::LabeledArrOrSubOrReshape) where T =
+    LabeledArray(collect(T, refarray(x)), getvaluelabels(x))
 
 # Assume VERSION >= v"1.3.0"
 # Define abbreviated element type name for printing with PrettyTables.jl

--- a/test/LabeledArrays.jl
+++ b/test/LabeledArrays.jl
@@ -174,29 +174,6 @@ end
     @test x == vals
     @test vals == x
 
-    x1 = copy(x)
-    @test x1 == x
-    @test refarray(x1) !== refarray(x)
-    @test typeof(x1) == typeof(x)
-    @test x1.labels === x.labels
-
-    dest = similar(refarray(x1))
-    copyto!(dest, x1)
-    @test isequal(dest, refarray(x1))
-    dest = similar(refarray(x1))
-    copyto!(IndexLinear(), dest, IndexLinear(), x1)
-    @test isequal(dest, refarray(x1))
-    dest = similar(refarray(x1))
-    copyto!(dest, 2, view(x1, 1:3))
-    @test isequal(dest[2:4], view(refarray(x1), 1:3))
-    copyto!(dest, 2:4, 1:1, x1, 1:3, 1:1)
-    @test isequal(dest[2:4], view(refarray(x1), 1:3))
-
-    x2 = collect(x)
-    @test x2 == x
-    @test x2 isa Array
-    @test eltype(x2) == eltype(x)
-
     x2 = convert(AbstractVector{LabeledValue{Int16,Union{Int,Missing}}}, x)
     @test typeof(x2) == LabeledVector{Int16, Vector{Int16}, Union{Int,Missing}}
     @test x2.values == x.values
@@ -232,6 +209,39 @@ end
     @test size(s) == (3, 3)
     copyto!(s, 1:3, 1:1, x, 1:3, 1:1)
     @test s[1:3] == x[1:3]
+
+    x1 = copy(x)
+    @test x1 == x
+    @test refarray(x1) !== refarray(x)
+    @test typeof(x1) == typeof(x)
+    @test x1.labels === x.labels
+
+    dest = similar(refarray(x1))
+    copyto!(dest, x1)
+    @test isequal(dest, refarray(x1))
+    dest = similar(refarray(x1))
+    copyto!(IndexLinear(), dest, IndexLinear(), x1)
+    @test isequal(dest, refarray(x1))
+    dest = similar(refarray(x1))
+    copyto!(dest, 2, view(x1, 1:3))
+    @test isequal(dest[2:4], view(refarray(x1), 1:3))
+    copyto!(dest, 2:4, 1:1, x1, 1:3, 1:1)
+    @test isequal(dest[2:4], view(refarray(x1), 1:3))
+
+    x2 = collect(x)
+    @test x2 == x
+    @test x2 isa LabeledArray
+    @test eltype(x2) == eltype(x)
+
+    x2 = collect(view(x, 1:3))
+    @test x2 == view(x, 1:3)
+    @test x2 isa LabeledArray
+    @test eltype(x2) == eltype(x)
+
+    x2 = collect(LabeledValue{Int16, Int}, view(x, 1:3))
+    @test x2 == view(x, 1:3)
+    @test x2 isa LabeledArray
+    @test eltype(x2) == LabeledValue{Int16, keytype(lbls)}
 
     lbs = valuelabels(x)
     @test size(lbs) == size(x)


### PR DESCRIPTION
An additional method of `similar` is included to avoid errors when joining `DataFrame`s containing `LabeledArray`s.