### PR TITLE
Support reading data with multiple threads

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,9 +11,11 @@ for parsing the data files.
 The same C library is also the backend of popular packages in other languages such as
 [pyreadstat](https://github.com/Roche/pyreadstat) for Python
 and [haven](https://github.com/tidyverse/haven) for R.
-ReadStatTables.jl can be viewed as the Julia counterpart for similar purposes.
+As the Julia counterpart for similar purposes,
+ReadStatTables.jl leverages the state-of-the-art Julia ecosystem
+for usability and performance.
 Its read performance dominates all related packages
-based on benchmark results
+based on the benchmark results
 [here](https://github.com/junyuan-chen/ReadStatTablesBenchmarks).
 
 ```@raw html
@@ -29,7 +31,7 @@ wrapping the C interface of ReadStat.
 
 - Efficient data collection from ReadStat parser to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible column table `ReadStatTable`.
 - Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl).
-- Integration of value labels into data columns via a customized array type `LabeledArray`.
+- Integration of value labels into data columns via a custom array type `LabeledArray`.
 - Translation of date and time values into Julia time types `Date` and `DateTime`.
 
 ## Supported File Formats

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,7 +17,7 @@ for usability and performance.
 Its read performance, especially when taking advantage of multiple threads,
 surpasses all related packages by a sizable margin
 based on the benchmark results
-[here](https://github.com/junyuan-chen/ReadStatTablesBenchmarks).
+[here](https://github.com/junyuan-chen/ReadStatTablesBenchmarks):
 
 ```@raw html
 <p align="center">

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,8 @@ and [haven](https://github.com/tidyverse/haven) for R.
 As the Julia counterpart for similar purposes,
 ReadStatTables.jl leverages the state-of-the-art Julia ecosystem
 for usability and performance.
-Its read performance dominates all related packages
+Its read performance, especially when taking advantage of multiple threads,
+surpasses all related packages by a sizable margin
 based on the benchmark results
 [here](https://github.com/junyuan-chen/ReadStatTablesBenchmarks).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ based on the benchmark results
 ## Features
 
 ReadStatTables.jl provides the following features in addition to
-wrapping the C interface of ReadStat.
+wrapping the C interface of ReadStat:
 
 - Efficient data collection from ReadStat parser to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible column table `ReadStatTable`.
 - Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl).
@@ -47,7 +47,7 @@ ReadStatTables.jl recognizes data files with the following file extensions at th
 
 ReadStatTables.jl can be installed with the Julia package manager
 [Pkg](https://docs.julialang.org/en/v1/stdlib/Pkg/).
-From the Julia REPL, type `]` to enter the Pkg REPL and run
+From the Julia REPL, type `]` to enter the Pkg REPL and run:
 
 ```
 pkg> add ReadStatTables

--- a/docs/src/man/getting-started.md
+++ b/docs/src/man/getting-started.md
@@ -149,6 +149,11 @@ File-level metadata can be obtained without reading the entire data file:
 readstatmeta
 ```
 
+To additionally collect variable-level metadata and all value labels:
+```@docs
+readstatallmeta
+```
+
 [^1]: The printed output is generated with [PrettyTables.jl](https://github.com/ronisbr/PrettyTables.jl).
 
 [^2]: The time types `Date` and `DateTime` are from the [Dates](https://docs.julialang.org/en/v1/stdlib/Dates/) module of Julia.

--- a/docs/src/man/value-labels.md
+++ b/docs/src/man/value-labels.md
@@ -1,7 +1,7 @@
 # Value Labels
 
 Value labels collected from the data files are incorporated into the associated data columns
-via a customized array type [`LabeledArray`](@ref).
+via a custom array type [`LabeledArray`](@ref).
 
 ## LabeledValue and LabeledArray
 
@@ -39,7 +39,7 @@ is not equivalent to that of an array type designed for categorical data
 [CategoricalArrays.jl](https://github.com/JuliaData/CategoricalArrays.jl)).
 They are not complete substitutes for each other.
 
-More details are below.
+More details are below:
 
 ```@docs
 LabeledValue

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -7,7 +7,7 @@ using InlineStrings
 using PooledArrays: PooledArray, PooledVector, RefArray
 using PrettyTables: pretty_table
 using ReadStat_jll
-using SentinelArrays: SentinelVector
+using SentinelArrays: SentinelVector, ChainedVector
 using StructArrays: StructVector
 using Tables
 
@@ -32,6 +32,7 @@ export LabeledValue,
        valuelabels,
 
        ReadStatColumns,
+       ChainedReadStatColumns,
 
        AbstractMetaDict,
        ReadStatMeta,
@@ -44,7 +45,8 @@ export LabeledValue,
        colmetavalues,
 
        readstat,
-       readstatmeta
+       readstatmeta,
+       readstatallmeta
 
 include("wrappers.jl")
 include("LabeledArrays.jl")

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -597,6 +597,15 @@ function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{PooledC
     return cols
 end
 
+# vs mixes PooledColumnVec and StringColumn
+function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{AbstractVector{String}})
+    cv = ChainedVector(collect(StringColumn, vs))
+    tar = getfield(cols, 2)
+    push!(tar, cv)
+    push!(cols.index, (2, length(tar)))
+    return cols
+end
+
 for (i, sz) in enumerate((3, 7, 15, 31, 63, 127, 255))
     coltype = Symbol(:Str, sz, :Column)
     @eval begin
@@ -607,19 +616,6 @@ for (i, sz) in enumerate((3, 7, 15, 31, 63, 127, 255))
             push!(cols.index, ($(15+i), length(tar)))
             return cols
         end
-    end
-end
-
-function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector)
-    coltypes = map(typeof, vs)
-    if PooledColumnVec in coltypes
-        cv = ChainedVector(collect(Vector{StringColumn}, vs))
-        tar = getfield(cols, 2)
-        push!(tar, cv)
-        push!(cols.index, (2, length(tar)))
-        return cols
-    else
-        throw(ArgumentError("unaccepted vs of type $(typeof(vs))"))
     end
 end
 

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -8,7 +8,8 @@ const FloatColumn = SentinelVector{Float32, Float32, Missing, Vector{Float32}}
 const DoubleColumn = SentinelVector{Float64, Float64, Missing, Vector{Float64}}
 const DateColumn = SentinelVector{Date, Date, Missing, Vector{Date}}
 const TimeColumn = SentinelVector{DateTime, DateTime, Missing, Vector{DateTime}}
-const PooledColumn = Tuple{PooledVector{String, UInt16, Vector{UInt16}}, Int}
+const PooledColumnVec = PooledVector{String, UInt16, Vector{UInt16}}
+const PooledColumn = Tuple{PooledColumnVec, Int}
 for sz in (3, 7, 15, 31, 63, 127, 255)
     colname = Symbol(:Str, sz, :Column)
     strtype = Symbol(:String, sz)
@@ -308,13 +309,329 @@ end
 
 Base.push!(cols::ReadStatColumns, vs...) = (foreach(v->push!(cols, v), vs); cols)
 
-Base.iterate(cols::ReadStatColumns, state=1) =
-    state > length(cols) ? nothing : (cols[state], state+1)
-
-ncol(cols::ReadStatColumns) = length(cols.index)
-nrow(cols::ReadStatColumns) = ncol(cols) > 0 ? length(cols[1])::Int : 0
-Base.size(cols::ReadStatColumns) = (nrow(cols), ncol(cols))
-Base.length(cols::ReadStatColumns) = ncol(cols)
-
 Base.show(io::IO, cols::ReadStatColumns) =
     print(io, nrow(cols), '×', ncol(cols), " ReadStatColumns")
+
+# Column types that will be directly chained together across tasks
+const _chainedcoltypes = (String => :StringColumn,
+    Union{Int8, Missing} => :Int8Column,
+    Union{Int16, Missing} => :Int16Column,
+    Union{Int32, Missing} => :Int32Column,
+    Union{Float32, Missing} => :FloatColumn,
+    Union{Float64, Missing} => :DoubleColumn,
+    String3 => :Str3Column, String7 => :Str7Column,
+    String15 => :Str15Column, String31 => :Str31Column,
+    String63 => :Str63Column, String127 => :Str127Column, String255 => :Str255Column)
+
+for (etype, coltype) in _chainedcoltypes
+    colname = Symbol(:Chained, coltype)
+    @eval const $colname = ChainedVector{$etype, $coltype}
+end
+
+"""
+    ChainedReadStatColumns
+
+A set of data columns obtained by lazily appending multiple `ReadStatColumns`.
+"""
+struct ChainedReadStatColumns
+    index::Vector{Tuple{Int,Int}}
+    string::Vector{ChainedStringColumn}
+    int8::Vector{ChainedInt8Column}
+    int8nm::Vector{Vector{Int8}}
+    int16::Vector{ChainedInt16Column}
+    int16nm::Vector{ChainedVector{Int16, Vector{Int16}}}
+    int32::Vector{ChainedInt32Column}
+    int32nm::Vector{ChainedVector{Int32, Vector{Int32}}}
+    float::Vector{ChainedFloatColumn}
+    floatnm::Vector{ChainedVector{Float32, Vector{Float32}}}
+    double::Vector{ChainedDoubleColumn}
+    doublenm::Vector{ChainedVector{Float64, Vector{Float64}}}
+    date::Vector{DateColumn}
+    time::Vector{TimeColumn}
+    pooled::Vector{PooledColumnVec}
+    str3::Vector{ChainedStr3Column}
+    str7::Vector{ChainedStr7Column}
+    str15::Vector{ChainedStr15Column}
+    str31::Vector{ChainedStr31Column}
+    str63::Vector{ChainedStr63Column}
+    str127::Vector{ChainedStr127Column}
+    str255::Vector{ChainedStr255Column}
+    ChainedReadStatColumns() = new(Tuple{Int,Int}[], ChainedStringColumn[],
+        ChainedInt8Column[], Vector{Int8}[],
+        ChainedInt16Column[], ChainedVector{Int16, Vector{Int16}}[],
+        ChainedInt32Column[], ChainedVector{Int32, Vector{Int32}}[],
+        ChainedFloatColumn[], ChainedVector{Float32, Vector{Float32}}[],
+        ChainedDoubleColumn[], ChainedVector{Float64, Vector{Float64}}[],
+        DateColumn[], TimeColumn[], PooledColumnVec[],
+        ChainedStr3Column[], ChainedStr7Column[], ChainedStr15Column[], ChainedStr31Column[],
+        ChainedStr63Column[], ChainedStr127Column[], ChainedStr255Column[])
+end
+
+Base.@propagate_inbounds function Base.getindex(cols::ChainedReadStatColumns, i::Int)
+    m, n = getfield(cols, 1)[i]
+    if m === 2
+        return getfield(cols, 2)[n]
+    elseif m === 3
+        return getfield(cols, 3)[n]
+    elseif m === 4
+        return getfield(cols, 4)[n]
+    elseif m === 5
+        return getfield(cols, 5)[n]
+    elseif m === 6
+        return getfield(cols, 6)[n]
+    elseif m === 7
+        return getfield(cols, 7)[n]
+    elseif m === 8
+        return getfield(cols, 8)[n]
+    elseif m === 9
+        return getfield(cols, 9)[n]
+    elseif m === 10
+        return getfield(cols, 10)[n]
+    elseif m === 11
+        return getfield(cols, 11)[n]
+    elseif m === 12
+        return getfield(cols, 12)[n]
+    elseif m === 13
+        return getfield(cols, 13)[n]
+    elseif m === 14
+        return getfield(cols, 14)[n]
+    elseif m === 15
+        return getfield(cols, 15)[n]
+    elseif m === 16
+        return getfield(cols, 16)[n]
+    elseif m === 17
+        return getfield(cols, 17)[n]
+    elseif m === 18
+        return getfield(cols, 18)[n]
+    elseif m === 19
+        return getfield(cols, 19)[n]
+    elseif m === 20
+        return getfield(cols, 20)[n]
+    elseif m === 21
+        return getfield(cols, 21)[n]
+    elseif m === 22
+        return getfield(cols, 22)[n]
+    end
+end
+
+Base.@propagate_inbounds function Base.getindex(cols::ChainedReadStatColumns, r, c::Int)
+    m, n = getfield(cols, 1)[c]
+    if m === 2
+        return getindex(getfield(cols, 2)[n], r)
+    elseif m === 3
+        return getindex(getfield(cols, 3)[n], r)
+    elseif m === 4
+        return getindex(getfield(cols, 4)[n], r)
+    elseif m === 5
+        return getindex(getfield(cols, 5)[n], r)
+    elseif m === 6
+        return getindex(getfield(cols, 6)[n], r)
+    elseif m === 7
+        return getindex(getfield(cols, 7)[n], r)
+    elseif m === 8
+        return getindex(getfield(cols, 8)[n], r)
+    elseif m === 9
+        return getindex(getfield(cols, 9)[n], r)
+    elseif m === 10
+        return getindex(getfield(cols, 10)[n], r)
+    elseif m === 11
+        return getindex(getfield(cols, 11)[n], r)
+    elseif m === 12
+        return getindex(getfield(cols, 12)[n], r)
+    elseif m === 13
+        return getindex(getfield(cols, 13)[n], r)
+    elseif m === 14
+        return getindex(getfield(cols, 14)[n], r)
+    elseif m === 15
+        return getindex(getfield(cols, 15)[n], r)
+    elseif m === 16
+        return getindex(getfield(cols, 16)[n], r)
+    elseif m === 17
+        return getindex(getfield(cols, 17)[n], r)
+    elseif m === 18
+        return getindex(getfield(cols, 18)[n], r)
+    elseif m === 19
+        return getindex(getfield(cols, 19)[n], r)
+    elseif m === 20
+        return getindex(getfield(cols, 20)[n], r)
+    elseif m === 21
+        return getindex(getfield(cols, 21)[n], r)
+    elseif m === 22
+        return getindex(getfield(cols, 22)[n], r)
+    end
+end
+
+Base.@propagate_inbounds function Base.setindex!(cols::ChainedReadStatColumns, v, r::Int, c::Int)
+    m, n = getfield(cols, 1)[c]
+    if m === 2
+        return setindex!(getfield(cols, 2)[n], v, r)
+    elseif m === 3
+        return setindex!(getfield(cols, 3)[n], v, r)
+    elseif m === 4
+        return setindex!(getfield(cols, 4)[n], v, r)
+    elseif m === 5
+        return setindex!(getfield(cols, 5)[n], v, r)
+    elseif m === 6
+        return setindex!(getfield(cols, 6)[n], v, r)
+    elseif m === 7
+        return setindex!(getfield(cols, 7)[n], v, r)
+    elseif m === 8
+        return setindex!(getfield(cols, 8)[n], v, r)
+    elseif m === 9
+        return setindex!(getfield(cols, 9)[n], v, r)
+    elseif m === 10
+        return setindex!(getfield(cols, 10)[n], v, r)
+    elseif m === 11
+        return setindex!(getfield(cols, 11)[n], v, r)
+    elseif m === 12
+        return setindex!(getfield(cols, 12)[n], v, r)
+    elseif m === 13
+        return setindex!(getfield(cols, 13)[n], v, r)
+    elseif m === 14
+        return setindex!(getfield(cols, 14)[n], v, r)
+    elseif m === 15
+        return setindex!(getfield(cols, 15)[n], v, r)
+    elseif m === 16
+        return setindex!(getfield(cols, 16)[n], v, r)
+    elseif m === 17
+        return setindex!(getfield(cols, 17)[n], v, r)
+    elseif m === 18
+        return setindex!(getfield(cols, 18)[n], v, r)
+    elseif m === 19
+        return setindex!(getfield(cols, 19)[n], v, r)
+    elseif m === 20
+        return setindex!(getfield(cols, 20)[n], v, r)
+    elseif m === 21
+        return setindex!(getfield(cols, 21)[n], v, r)
+    elseif m === 22
+        return setindex!(getfield(cols, 22)[n], v, r)
+    end
+end
+
+function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{StringColumn})
+    cv = ChainedVector(vs)
+    tar = getfield(cols, 2)
+    push!(tar, cv)
+    push!(cols.index, (2, length(tar)))
+    return cols
+end
+
+function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{Int8Column})
+    if hms
+        cv = ChainedVector(vs)
+        tar = getfield(cols, 3)
+        push!(tar, cv)
+        push!(cols.index, (3, length(tar)))
+        return cols
+    else
+        cv = Vector{Int8}(undef, sum(length, vs))
+        i1 = 1
+        for v in vs
+            copyto!(cv, i1, v)
+            i1 += length(v)
+        end
+        tar = getfield(cols, 4)
+        push!(tar, cv)
+        push!(cols.index, (4, length(tar)))
+        return cols
+    end
+end
+
+for (i, etype) in enumerate((:Int16, :Int32, :Float, :Double))
+    coltype = Symbol(etype, :Column)
+    @eval begin
+        function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{$coltype})
+            if hms
+                cv = ChainedVector(vs)
+                tar = getfield(cols, $(3+2*i))
+                push!(tar, cv)
+                push!(cols.index, ($(3+2*i), length(tar)))
+                return cols
+            else
+                cv = ChainedVector(map(parent, vs))
+                tar = getfield(cols, $(4+2*i))
+                push!(tar, cv)
+                push!(cols.index, ($(4+2*i), length(tar)))
+                return cols
+            end
+        end
+    end
+end
+
+function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{PooledColumnVec})
+    v1 = vs[1]
+    refs = v1.refs
+    pool = v1.pool
+    invpool = v1.invpool
+    i0 = length(refs)
+    resize!(refs, sum(length, vs))
+    refmap = Dict{UInt16, UInt16}()
+    nlbls = UInt16(length(pool))
+    z = zero(UInt16)
+    o = one(UInt16)
+    @inbounds for n in 2:length(vs)
+        vn = vs[n]
+        lbln = o
+        for x in vn.pool
+            lbl = get(invpool, x, z)
+            if iszero(lbl)
+                nlbls += o
+                invpool[x] = nlbls
+                refmap[lbln] = nlbls
+                push!(pool, x)
+            else
+                refmap[lbln] = lbl
+            end
+            lbln += o
+        end
+        refsn = vn.refs
+        for i in 1:length(vn)
+            refs[i0+i] = refmap[refsn[i]]
+        end
+        i0 += length(refsn)
+    end
+    pv = PooledArray(RefArray(refs), invpool, pool)
+    tar = getfield(cols, 15)
+    push!(tar, pv)
+    push!(cols.index, (15, length(tar)))
+    return cols
+end
+
+for (i, sz) in enumerate((3, 7, 15, 31, 63, 127, 255))
+    coltype = Symbol(:Str, sz, :Column)
+    @eval begin
+        function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{$coltype})
+            cv = ChainedVector(vs)
+            tar = getfield(cols, $(15+i))
+            push!(tar, cv)
+            push!(cols.index, ($(15+i), length(tar)))
+            return cols
+        end
+    end
+end
+
+function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector)
+    coltypes = map(typeof, vs)
+    if PooledColumnVec in coltypes
+        cv = ChainedVector(collect(Vector{StringColumn}, vs))
+        tar = getfield(cols, 2)
+        push!(tar, cv)
+        push!(cols.index, (2, length(tar)))
+        return cols
+    else
+        throw(ArgumentError("unaccepted vs of type $(typeof(vs))"))
+    end
+end
+
+const ColumnsOrChained = Union{ReadStatColumns, ChainedReadStatColumns}
+
+Base.iterate(cols::ColumnsOrChained, state=1) =
+    state > length(cols) ? nothing : (cols[state], state+1)
+
+ncol(cols::ColumnsOrChained) = length(cols.index)
+nrow(cols::ColumnsOrChained) = ncol(cols) > 0 ? length(cols[1])::Int : 0
+Base.size(cols::ColumnsOrChained) = (nrow(cols), ncol(cols))
+Base.length(cols::ColumnsOrChained) = ncol(cols)
+
+Base.show(io::IO, cols::ChainedReadStatColumns) =
+    print(io, nrow(cols), '×', ncol(cols), " ChainedReadStatColumns")

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -319,6 +319,8 @@ const _chainedcoltypes = (String => :StringColumn,
     Union{Int32, Missing} => :Int32Column,
     Union{Float32, Missing} => :FloatColumn,
     Union{Float64, Missing} => :DoubleColumn,
+    Union{Date, Missing} => :DateColumn,
+    Union{DateTime, Missing} => :TimeColumn,
     String3 => :Str3Column, String7 => :Str7Column,
     String15 => :Str15Column, String31 => :Str31Column,
     String63 => :Str63Column, String127 => :Str127Column, String255 => :Str255Column)
@@ -346,8 +348,10 @@ struct ChainedReadStatColumns
     floatnm::Vector{ChainedVector{Float32, Vector{Float32}}}
     double::Vector{ChainedDoubleColumn}
     doublenm::Vector{ChainedVector{Float64, Vector{Float64}}}
-    date::Vector{DateColumn}
-    time::Vector{TimeColumn}
+    date::Vector{ChainedDateColumn}
+    datenm::Vector{ChainedVector{Date, Vector{Date}}}
+    time::Vector{ChainedTimeColumn}
+    timenm::Vector{ChainedVector{DateTime, Vector{DateTime}}}
     pooled::Vector{PooledColumnVec}
     str3::Vector{ChainedStr3Column}
     str7::Vector{ChainedStr7Column}
@@ -362,9 +366,11 @@ struct ChainedReadStatColumns
         ChainedInt32Column[], ChainedVector{Int32, Vector{Int32}}[],
         ChainedFloatColumn[], ChainedVector{Float32, Vector{Float32}}[],
         ChainedDoubleColumn[], ChainedVector{Float64, Vector{Float64}}[],
-        DateColumn[], TimeColumn[], PooledColumnVec[],
-        ChainedStr3Column[], ChainedStr7Column[], ChainedStr15Column[], ChainedStr31Column[],
-        ChainedStr63Column[], ChainedStr127Column[], ChainedStr255Column[])
+        ChainedDateColumn[], ChainedVector{Date, Vector{Date}}[],
+        ChainedTimeColumn[], ChainedVector{DateTime, Vector{DateTime}}[],
+        PooledColumnVec[], ChainedStr3Column[], ChainedStr7Column[],
+        ChainedStr15Column[], ChainedStr31Column[], ChainedStr63Column[],
+        ChainedStr127Column[], ChainedStr255Column[])
 end
 
 Base.@propagate_inbounds function Base.getindex(cols::ChainedReadStatColumns, i::Int)
@@ -411,6 +417,10 @@ Base.@propagate_inbounds function Base.getindex(cols::ChainedReadStatColumns, i:
         return getfield(cols, 21)[n]
     elseif m === 22
         return getfield(cols, 22)[n]
+    elseif m === 23
+        return getfield(cols, 23)[n]
+    elseif m === 24
+        return getfield(cols, 24)[n]
     end
 end
 
@@ -458,6 +468,10 @@ Base.@propagate_inbounds function Base.getindex(cols::ChainedReadStatColumns, r,
         return getindex(getfield(cols, 21)[n], r)
     elseif m === 22
         return getindex(getfield(cols, 22)[n], r)
+    elseif m === 23
+        return getindex(getfield(cols, 23)[n], r)
+    elseif m === 24
+        return getindex(getfield(cols, 24)[n], r)
     end
 end
 
@@ -505,6 +519,10 @@ Base.@propagate_inbounds function Base.setindex!(cols::ChainedReadStatColumns, v
         return setindex!(getfield(cols, 21)[n], v, r)
     elseif m === 22
         return setindex!(getfield(cols, 22)[n], v, r)
+    elseif m === 23
+        return setindex!(getfield(cols, 23)[n], v, r)
+    elseif m === 24
+        return setindex!(getfield(cols, 24)[n], v, r)
     end
 end
 
@@ -537,7 +555,7 @@ function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{Int8Col
     end
 end
 
-for (i, etype) in enumerate((:Int16, :Int32, :Float, :Double))
+for (i, etype) in enumerate((:Int16, :Int32, :Float, :Double, :Date, :Time))
     coltype = Symbol(etype, :Column)
     @eval begin
         function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{$coltype})
@@ -591,9 +609,9 @@ function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{PooledC
         i0 += length(refsn)
     end
     pv = PooledArray(RefArray(refs), invpool, pool)
-    tar = getfield(cols, 15)
+    tar = getfield(cols, 17)
     push!(tar, pv)
-    push!(cols.index, (15, length(tar)))
+    push!(cols.index, (17, length(tar)))
     return cols
 end
 
@@ -611,9 +629,9 @@ for (i, sz) in enumerate((3, 7, 15, 31, 63, 127, 255))
     @eval begin
         function _pushchain!(cols::ChainedReadStatColumns, hms::Bool, vs::Vector{$coltype})
             cv = ChainedVector(vs)
-            tar = getfield(cols, $(15+i))
+            tar = getfield(cols, $(17+i))
             push!(tar, cv)
-            push!(cols.index, ($(15+i), length(tar)))
+            push!(cols.index, ($(17+i), length(tar)))
             return cols
         end
     end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -3,52 +3,31 @@ const jltypes = (String, Int8, Int16, Int32, Float32, Float64, String)
 jltype(type::readstat_type_t) = jltypes[convert(Int, type)+1]
 
 mutable struct ParserContext
-    tb::ReadStatTable
+    tb::ReadStatTable{ReadStatColumns}
     usecols::Union{UnitRange, Set, Nothing}
     inlinestring_width::Int
     pool_width::Int
     pool_thres::Int
 end
 
-parse_dta(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ParserContext}) =
-    ccall((:readstat_parse_dta, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ParserContext}), parser, path, user_ctx)
+mutable struct AllMetaContext
+    meta::ReadStatMeta
+    names::Vector{Symbol}
+    colmeta::ColMetaVec
+    vallabels::Dict{Symbol, Dict}
+    usecols::Union{UnitRange, Set, Nothing}
+end
 
-parse_dta(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ReadStatMeta}) =
-    ccall((:readstat_parse_dta, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ReadStatMeta}), parser, path, user_ctx)
-
-parse_sav(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ParserContext}) =
-    ccall((:readstat_parse_sav, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ParserContext}), parser, path, user_ctx)
-
-parse_sav(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ReadStatMeta}) =
-    ccall((:readstat_parse_sav, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ReadStatMeta}), parser, path, user_ctx)
-
-parse_por(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ParserContext}) =
-    ccall((:readstat_parse_por, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ParserContext}), parser, path, user_ctx)
-
-parse_por(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ReadStatMeta}) =
-    ccall((:readstat_parse_por, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ReadStatMeta}), parser, path, user_ctx)
-
-parse_sas7bdat(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ParserContext}) =
-    ccall((:readstat_parse_sas7bdat, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ParserContext}), parser, path, user_ctx)
-
-parse_sas7bdat(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ReadStatMeta}) =
-    ccall((:readstat_parse_sas7bdat, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ReadStatMeta}), parser, path, user_ctx)
-
-parse_xport(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ParserContext}) =
-    ccall((:readstat_parse_xport, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ParserContext}), parser, path, user_ctx)
-
-parse_xport(parser::Ptr{Cvoid}, path::AbstractString, user_ctx::Ref{ReadStatMeta}) =
-    ccall((:readstat_parse_xport, libreadstat),
-        readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{ReadStatMeta}), parser, path, user_ctx)
+for ext in (:dta, :sav, :por, :sas7bdat, :xport)
+    for ctxtype in (ParserContext, ReadStatMeta, AllMetaContext)
+        parse_ext = Symbol(:parse_, ext)
+        readstat_parse_ext = QuoteNode(Symbol(:readstat_parse_, ext))
+        @eval begin $parse_ext(parser::Ptr{Cvoid}, path::AbstractString,
+            user_ctx::Ref{$ctxtype}) = ccall(($readstat_parse_ext, libreadstat),
+            readstat_error_t, (Ptr{Cvoid}, Cstring, Ref{$ctxtype}), parser, path, user_ctx)
+        end
+    end
+end
 
 const ext2parser = Dict{String, Any}(
     ".dta" => parse_dta,
@@ -76,6 +55,9 @@ end
 handle_metadata!(metadata::Ptr{Cvoid}, ctx::ParserContext) =
     handle_metadata!(metadata, _meta(ctx.tb))
 
+handle_metadata!(metadata::Ptr{Cvoid}, ctx::AllMetaContext) =
+    handle_metadata!(metadata, ctx.meta)
+
 function handle_note!(note_index::Cint, note::Cstring, m::ReadStatMeta)
     # For Stata, note_index=0 gives the total number of notes
     # For SAS, each note is attached with a date that comes with the next note_index
@@ -94,48 +76,30 @@ end
 handle_note!(note_index::Cint, note::Cstring, ctx::ParserContext) =
     handle_note!(note_index, note, _meta(ctx.tb))
 
-function handle_variable!(index::Cint, variable::Ptr{Cvoid}, val_labels::Cstring,
-        ctx::ParserContext)
-    tb = ctx.tb
-    m = _meta(tb)
-    usecols = ctx.usecols
-    icol = index + 1
-    name = Symbol(variable_get_name(variable))
-    if usecols !== nothing
-        if !(icol in usecols || name in usecols)
-            return READSTAT_HANDLER_SKIP_VARIABLE
-        else
-            icol = variable_get_index_after_skipping(variable) + 1
-        end
-    end
-    push!(_names(tb), name)
-    _lookup(tb)[name] = icol
-    colmetas = _colmeta(tb)
-    push!(colmetas.label, variable_get_label(variable))
-    push!(colmetas.format, variable_get_format(variable))
-    type = variable_get_type(variable)
-    push!(colmetas.type, type)
-    push!(colmetas.vallabel, Symbol(_string(val_labels)))
-    width = variable_get_storage_width(variable)
-    push!(colmetas.storage_width, width)
-    push!(colmetas.display_width, variable_get_display_width(variable))
-    push!(colmetas.measure, variable_get_measure(variable))
-    push!(colmetas.alignment, variable_get_alignment(variable))
+handle_note!(note_index::Cint, note::Cstring, ctx::AllMetaContext) =
+    handle_note!(note_index, note, ctx.meta)
 
-    # Row count is not always available from metadata
-    N = max(m.row_count, 0)
-    cols = _columns(tb)
-    inlinestring_width = ctx.inlinestring_width
-    pool_thres = ctx.pool_thres
-    usepool = pool_thres > 0
-    T = jltype(type)
+function _pushcolmeta!(colmeta, variable, val_labels)
+    push!(colmeta.label, variable_get_label(variable))
+    push!(colmeta.format, variable_get_format(variable))
+    type = variable_get_type(variable)
+    push!(colmeta.type, type)
+    push!(colmeta.vallabel, Symbol(_string(val_labels)))
+    width = variable_get_storage_width(variable)
+    push!(colmeta.storage_width, width)
+    push!(colmeta.display_width, variable_get_display_width(variable))
+    push!(colmeta.measure, variable_get_measure(variable))
+    push!(colmeta.alignment, variable_get_alignment(variable))
+    return type, width
+end
+
+function _pushcolumn!(cols, T, N, width, width_offset, inlinestring_width, pool_width, pool_thres)
     if T === String
         # No "" for String1
         # StrL in Stata has width being 0
-        width_offset = Int(m.file_ext == ".dta")
-        if (width == 0 || width >= ctx.pool_width + width_offset) && usepool
-            push!(cols, (PooledArray(RefArray(fill(zero(UInt16), N)),
-                Dict(""=>zero(UInt16)), [""]), pool_thres))
+        if (width == 0 || width >= pool_width + width_offset) && pool_thres > 0
+            push!(cols, (PooledArray(RefArray(fill(one(UInt16), N)),
+                Dict(""=>one(UInt16)), [""]), pool_thres))
         elseif width < min(4, inlinestring_width) + width_offset
             push!(cols, fill(String3(), N))
         elseif width < min(8, inlinestring_width) + width_offset
@@ -160,8 +124,63 @@ function handle_variable!(index::Cint, variable::Ptr{Cvoid}, val_labels::Cstring
     else
         push!(cols, SentinelVector{T}(undef, N))
     end
+end
+
+function handle_variable!(index::Cint, variable::Ptr{Cvoid}, val_labels::Cstring,
+        ctx::ParserContext)
+    tb = ctx.tb
+    m = _meta(tb)
+    usecols = ctx.usecols
+    icol = index + 1
+    name = Symbol(variable_get_name(variable))
+    if usecols !== nothing
+        if !(icol in usecols || name in usecols)
+            return READSTAT_HANDLER_SKIP_VARIABLE
+        else
+            icol = variable_get_index_after_skipping(variable) + 1
+        end
+    end
+    push!(_names(tb), name)
+    _lookup(tb)[name] = icol
+    type, width = _pushcolmeta!(_colmeta(tb), variable, val_labels)
+
+    # Row count is not always available from metadata
+    N = max(m.row_count, 0)
+    cols = _columns(tb)
+    T = jltype(type)
+    _pushcolumn!(cols, T, N, width, Int(m.file_ext == ".dta"),
+        ctx.inlinestring_width, ctx.pool_width, ctx.pool_thres)
     push!(_hasmissing(tb), false)
     return READSTAT_HANDLER_OK
+end
+
+function handle_variable_meta!(index::Cint, variable::Ptr{Cvoid}, val_labels::Cstring,
+        ctx::AllMetaContext)
+    usecols = ctx.usecols
+    icol = index + 1
+    name = Symbol(variable_get_name(variable))
+    if usecols !== nothing && !(icol in usecols || name in usecols)
+        return READSTAT_HANDLER_SKIP_VARIABLE
+    end
+    push!(ctx.names, name)
+    _pushcolmeta!(ctx.colmeta, variable, val_labels)
+    return READSTAT_HANDLER_OK
+end
+
+function handle_variable_chunk!(index::Cint, variable::Ptr{Cvoid}, val_labels::Cstring,
+        ctx::ParserContext)
+    usecols = ctx.usecols
+    if usecols === nothing
+        return READSTAT_HANDLER_OK
+    else
+        icol = index + 1
+        name = Symbol(variable_get_name(variable))
+        if !(icol in usecols || name in usecols)
+            return READSTAT_HANDLER_SKIP_VARIABLE
+        else
+            return READSTAT_HANDLER_OK
+        end
+    end
 end
 
 function handle_value!(obs_index::Cint, variable::Ptr{Cvoid}, value::readstat_value_t,
@@ -185,37 +204,41 @@ function handle_value!(obs_index::Cint, variable::Ptr{Cvoid}, value::readstat_va
     return READSTAT_HANDLER_OK
 end
 
-function handle_value_label!(val_labels::Cstring, value::readstat_value_t, label::Cstring,
-        ctx::ParserContext)
-    tb = ctx.tb
+function _handle_value_label!(val_labels, value, label, vallabels)
     lblname = Symbol(_string(val_labels))
     type = value_type(value)
     # String variables do not have value labels
     # All integers are Int32 and all floats are Float64 (ReadStat handles type conversion)
     # Tentatively save tagged missing values as Char
     if Int(type) <= 3
-        lbls = get!(Dict{Union{Int32,Char},String}, _vallabels(tb), lblname)
+        lbls = get!(Dict{Union{Int32,Char},String}, vallabels, lblname)
         val = value_is_tagged_missing(value) ? value_tag(value) : int32_value(value)
         lbls[val] = _string(label)
     else
-        lbls = get!(Dict{Union{Float64,Char},String}, _vallabels(tb), lblname)
+        lbls = get!(Dict{Union{Float64,Char},String}, vallabels, lblname)
         val = value_is_tagged_missing(value) ? value_tag(value) : double_value(value)
         lbls[val] = _string(label)
     end
     return READSTAT_HANDLER_OK
 end
 
+handle_value_label!(val_labels::Cstring, value::readstat_value_t, label::Cstring,
+    ctx::ParserContext) =
+        _handle_value_label!(val_labels, value, label, _vallabels(ctx.tb))
+
+handle_value_label!(val_labels::Cstring, value::readstat_value_t, label::Cstring,
+    ctx::AllMetaContext) =
+        _handle_value_label!(val_labels, value, label, ctx.vallabels)
+
 _error(e::readstat_error_t) = e === READSTAT_OK ? nothing : error(error_message(e))
 
-function _parse_all(filepath, ext, usecols, row_limit, row_offset,
+function _parse_all(filepath, ext, parse_ext, usecols, row_limit, row_offset,
         inlinestring_width, pool_width, pool_thres, file_encoding, handler_encoding)
-    parse_ext = get(ext2parser, ext, nothing)
-    parse_ext === nothing && throw(ArgumentError("file extension $ext is not supported"))
     tb = ReadStatTable()
     m = _meta(tb)
     m.file_ext = ext
-    ctx = ParserContext(tb, usecols, inlinestring_width, pool_width, pool_thres)
-    refctx = Ref{ParserContext}(ctx)
+    ctx = Ref{ParserContext}(
+        ParserContext(tb, usecols, inlinestring_width, pool_width, pool_thres))
     parser = parser_init()
     set_metadata_handler(parser, @cfunction(handle_metadata!,
         readstat_handler_status, (Ptr{Cvoid}, Ref{ParserContext})))
@@ -234,7 +257,52 @@ function _parse_all(filepath, ext, usecols, row_limit, row_offset,
     handler_encoding === nothing ||
         _error(set_handler_character_encoding(parser, handler_encoding))
     # Run the parser
-    _error(parse_ext(parser, filepath, refctx))
+    _error(parse_ext(parser, filepath, ctx))
     parser_free(parser)
-    return ctx
+    return tb
+end
+
+function _parse_allmeta(filepath, ext, parse_ext, usecols, file_encoding, handler_encoding)
+    m = ReadStatMeta()
+    m.file_ext = ext
+    names = Symbol[]
+    cm = StructVector{ReadStatColMeta}((String[], String[], readstat_type_t[],
+            Symbol[], Csize_t[], Cint[], readstat_measure_t[], readstat_alignment_t[]))
+    vlbls = Dict{Symbol, Dict}()
+    ctx = Ref{AllMetaContext}(AllMetaContext(m, names, cm, vlbls, usecols))
+    parser = parser_init()
+    set_metadata_handler(parser, @cfunction(handle_metadata!,
+        readstat_handler_status, (Ptr{Cvoid}, Ref{AllMetaContext})))
+    set_note_handler(parser, @cfunction(handle_note!,
+        readstat_handler_status, (Cint, Cstring, Ref{AllMetaContext})))
+    set_variable_handler(parser, @cfunction(handle_variable_meta!,
+        readstat_handler_status, (Cint, Ptr{Cvoid}, Cstring, Ref{AllMetaContext})))
+    set_value_label_handler(parser, @cfunction(handle_value_label!,
+        readstat_handler_status, (Cstring, readstat_value_t, Cstring, Ref{AllMetaContext})))
+    file_encoding === nothing ||
+        _error(set_file_character_encoding(parser, file_encoding))
+    handler_encoding === nothing ||
+        _error(set_handler_character_encoding(parser, handler_encoding))
+    _error(parse_ext(parser, filepath, ctx))
+    parser_free(parser)
+    return m, names, cm, vlbls
+end
+
+function _parse_chunk!(tb, filepath, parse_ext, usecols, row_limit, row_offset,
+        pool_thres, file_encoding, handler_encoding)
+    ctx = Ref{ParserContext}(ParserContext(tb, usecols, 0, 0, pool_thres))
+    parser = parser_init()
+    set_variable_handler(parser, @cfunction(handle_variable_chunk!,
+        readstat_handler_status, (Cint, Ptr{Cvoid}, Cstring, Ref{ParserContext})))
+    set_value_handler(parser, @cfunction(handle_value!,
+        readstat_handler_status, (Cint, Ptr{Cvoid}, readstat_value_t, Ref{ParserContext})))
+    _error(set_row_limit(parser, row_limit))
+    _error(set_row_offset(parser, row_offset))
+    file_encoding === nothing ||
+        _error(set_file_character_encoding(parser, file_encoding))
+    handler_encoding === nothing ||
+        _error(set_handler_character_encoding(parser, handler_encoding))
+    # Run the parser
+    _error(parse_ext(parser, filepath, ctx))
+    parser_free(parser)
 end

--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -143,7 +143,8 @@ function readstat(filepath;
                         end
                     end
                     tbs[i] = tasktb
-            end end
+                end
+            end
             cols = ChainedReadStatColumns()
             hms = Vector{Bool}(undef, ncols)
             for i in 1:ncols

--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -152,7 +152,7 @@ function readstat(filepath;
                 @inbounds hms[i] = hmsi
                 _pushchain!(cols, hmsi, map(x->@inbounds(_columns(x)[i]), tbs))
             end
-            tb = ReadStatTable(cols, names, vlbls, hms, m, cm)
+            return ReadStatTable(cols, names, vlbls, hms, m, cm)
         end
     end
 

--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -143,8 +143,7 @@ function readstat(filepath;
                         end
                     end
                     tbs[i] = tasktb
-                end
-            end
+            end end
             cols = ChainedReadStatColumns()
             hms = Vector{Bool}(undef, ncols)
             for i in 1:ncols

--- a/src/table.jl
+++ b/src/table.jl
@@ -290,9 +290,9 @@ Base.@propagate_inbounds function getcolumnfast(tb::ReadStatTable{ChainedReadSta
     elseif m === 12
         return getfield(cols, 12)[n]
     elseif m === 13
-        return _hasmissing(tb)[i] ? getfield(cols, 13)[n] : parent(getfield(cols, 13)[n])
+        return getfield(cols, 13)[n]
     elseif m === 14
-        return _hasmissing(tb)[i] ? getfield(cols, 14)[n] : parent(getfield(cols, 14)[n])
+        return getfield(cols, 14)[n]
     elseif m === 15
         return getfield(cols, 15)[n]
     elseif m === 16
@@ -309,6 +309,10 @@ Base.@propagate_inbounds function getcolumnfast(tb::ReadStatTable{ChainedReadSta
         return getfield(cols, 21)[n]
     elseif m === 22
         return getfield(cols, 22)[n]
+    elseif m === 23
+        return getfield(cols, 23)[n]
+    elseif m === 24
+        return getfield(cols, 24)[n]
     end
 end
 

--- a/test/columns.jl
+++ b/test/columns.jl
@@ -7,7 +7,7 @@ function gettestcolumns(N::Int)
     doublecol = SentinelVector{Float64}(undef, N)
     datecol = SentinelVector{Date}(undef, N)
     timecol = SentinelVector{DateTime}(undef, N)
-    pooledcol = (PooledArray(fill("", N), UInt16), 1000)
+    pooledcol = (PooledArray(fill("", N), UInt16), 100)
     str3col = fill(String3(), N)
     str7col = fill(String7(), N)
     str15col = fill(String15(), N)
@@ -40,7 +40,8 @@ end
     end
     @test sprint(show, cols) == "10×16 ReadStatColumns"
 
-    vals = ["a", Int8(1), Int16(1), Int32(1), Float32(1), Float64(1), Date(1), DateTime(1), ("a" for _ in 1:8)...]
+    vals = ["a", Int8(1), Int16(1), Int32(1), Float32(1), Float64(1), Date(1), DateTime(1),
+        ("a" for _ in 1:8)...]
     for (i, (v, col)) in enumerate(zip(vals, columns))
         cols[1,i] = v
         @test cols[1,i] == v
@@ -66,4 +67,98 @@ end
 
     @test iterate(cols) === (cols[1], 2)
     @test iterate(cols, 17) === nothing
+end
+
+function gettestchainedcolumns(N::Int)
+    strcol = ChainedVector([fill("", N), fill("", N)])
+    int8col = Vector{Union{Int8, Missing}}(missing, N)
+    int8col = ChainedVector([int8col, copy(int8col)])
+    int8nmcol = fill(Int8(1), 2*N)
+    int16col = SentinelVector{Int16}(undef, N)
+    int16col = ChainedVector([int16col, int16col])
+    int16nmcol = ChainedVector([fill(Int16(1), N), fill(Int16(1), N)])
+    int32col = SentinelVector{Int32}(undef, N)
+    int32col = ChainedVector([int32col, int32col])
+    int32nmcol = ChainedVector([fill(Int32(1), N), fill(Int32(1), N)])
+    floatcol = SentinelVector{Float32}(undef, N)
+    floatcol = ChainedVector([floatcol, floatcol])
+    floatnmcol = ChainedVector([fill(Float32(1), N), fill(Float32(1), N)])
+    doublecol = SentinelVector{Float64}(undef, N)
+    doublecol = ChainedVector([doublecol, doublecol])
+    doublenmcol = ChainedVector([fill(Float64(1), N), fill(Float64(1), N)])
+    datecol = SentinelVector{Date}(undef, N)
+    timecol = SentinelVector{DateTime}(undef, N)
+    pooledcol = PooledArray(fill("", 2*N), UInt16)
+    str3col = ChainedVector([fill(String3(), N), fill(String3(), N)])
+    str7col = ChainedVector([fill(String7(), N), fill(String7(), N)])
+    str15col = ChainedVector([fill(String15(), N), fill(String15(), N)])
+    str31col = ChainedVector([fill(String31(), N), fill(String31(), N)])
+    str63col = ChainedVector([fill(String63(), N), fill(String63(), N)])
+    str127col = ChainedVector([fill(String127(), N), fill(String127(), N)])
+    str255col = ChainedVector([fill(String255(), N), fill(String255(), N)])
+    columns = (strcol, int8col, int8nmcol, int16col, int16nmcol, int32col, int32nmcol,
+        floatcol, floatnmcol, doublecol, doublenmcol, datecol, timecol, pooledcol,
+        str3col, str7col, str15col, str31col, str63col, str127col, str255col)
+    cols = ChainedReadStatColumns()
+    for i in 1:length(columns)
+        push!(cols.index, (i+1, 1))
+        push!(getfield(cols, i+1), columns[i])
+    end
+    return columns, cols
+end
+
+@testset "ChainedReadStatColumns" begin
+    cols = ChainedReadStatColumns()
+    @test size(cols) == (0, 0)
+    @test length(cols) == 0
+    @test iterate(cols) === nothing
+    @test sprint(show, cols) == "0×0 ChainedReadStatColumns"
+
+    columns1 = gettestcolumns(5)[vcat(1:6, 9:16)]
+    columns2 = gettestcolumns(5)[vcat(1:6, 9:16)]
+    for (i, (col1, col2)) in enumerate(zip(columns1, columns2))
+        if i == 7
+            _pushchain!(cols, true, [col1[1], col2[1]])
+        else
+            _pushchain!(cols, true, [col1, col2])
+        end
+        if i in 2:6
+            fill!(col1, 1)
+            fill!(col2, 1)
+            _pushchain!(cols, false, [col1, col2])
+        end
+    end
+    _pushchain!(cols, false, [columns1[9], columns1[1]])
+    @test size(cols) == (10, 20)
+    @test length(cols) == 20
+    @test cols.index == [((n, 1) for n in vcat(2:12, 15:22))..., (2, 2)]
+
+    pv1 = PooledArray(fill("a", 3), UInt16)
+    pv2 = PooledArray(fill("b", 3), UInt16)
+    _pushchain!(cols, false, [pv1, pv2])
+    @test cols[21].refs == vcat(fill(UInt16(1), 3), fill(UInt16(2), 3))
+    @test cols[21].pool == ["a", "b"]
+    _pushchain!(cols, false, [pv1])
+    @test cols[22] == pv1
+
+    columns, cols = gettestchainedcolumns(5)
+    for (i, col) in enumerate(columns)
+        @test cols[i] === col
+    end
+    @test sprint(show, cols) == "10×21 ChainedReadStatColumns"
+
+    vals = ["a", Int8(1), Int8(1), Int16(1), Int16(1), Int32(1), Int32(1),
+        Float32(1), Float32(1), Float64(1), Float64(1), Date(1), DateTime(1),
+        ("a" for _ in 1:8)...]
+    for (i, v) in enumerate(vals)
+        cols[1,i] = v
+        @test cols[1,i] == v
+        if i in 2:2:10
+            cols[1,i] = missing
+            @test ismissing(cols[1,i])
+        end
+    end
+
+    @test iterate(cols) === (cols[1], 2)
+    @test iterate(cols, 22) === nothing
 end

--- a/test/columns.jl
+++ b/test/columns.jl
@@ -128,7 +128,7 @@ end
             _pushchain!(cols, false, [col1, col2])
         end
     end
-    _pushchain!(cols, false, [columns1[9], columns1[1]])
+    _pushchain!(cols, false, [columns1[7][1], columns1[1]])
     @test size(cols) == (10, 20)
     @test length(cols) == 20
     @test cols.index == [((n, 1) for n in vcat(2:12, 15:22))..., (2, 2)]

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -84,6 +84,12 @@ end
     @test d isa ReadStatTable{ChainedReadStatColumns}
     @test length(d.mychar.arrays[1]) == 3
 
+    d = readstat(dta, usecols=Int[], ntasks=2)
+    @test d isa ReadStatTable{ChainedReadStatColumns}
+    @test sprint(show, d) == "0×0 ReadStatTable"
+    @test isempty(colmetadata(d))
+    @test length(getvaluelabels(d)) == 2
+
     d = readstat(dta, usecols=1:3, row_offset=10, ntasks=2)
     @test size(d) == (0, 3)
     @test d isa ReadStatTable{ReadStatColumns}

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -104,6 +104,7 @@ end
            2 │       d     -1.4  1583-01-01"""
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == showstr
     d = readstat(dta, usecols=1:3, row_limit=2, row_offset=2, ntasks=2, convert_datetime=true)
+    @test d isa ReadStatTable{ChainedReadStatColumns}
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == showstr
 
     d = readstat(dta, usecols=[:dtime, :mylabl], convert_datetime=false,
@@ -121,6 +122,7 @@ end
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == showstr
     d = readstat(dta, usecols=[:dtime, :mylabl], ntasks=2, convert_datetime=false,
         file_encoding="UTF-8", handler_encoding="UTF-8")
+    @test d isa ReadStatTable{ChainedReadStatColumns}
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == showstr
 
     d = readstat(dta, usecols=Set(["dtime", "mylabl"]), row_limit=4)
@@ -135,6 +137,7 @@ end
            4 │ 1583-01-01T00:00:00         Female"""
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == showstr
     d = readstat(dta, usecols=Set(["dtime", "mylabl"]), row_limit=4, ntasks=2)
+    @test d isa ReadStatTable{ChainedReadStatColumns}
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == showstr
 
     d = readstat(dta, usecols=:myord)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,9 @@ using InlineStrings
 using PooledArrays
 using ReadStatTables: error_message, READSTAT_COMPRESS_NONE, READSTAT_ENDIAN_NONE,
     READSTAT_TYPE_INT8, READSTAT_TYPE_DOUBLE, READSTAT_MEASURE_UNKNOWN,
-    READSTAT_ALIGNMENT_UNKNOWN, READSTAT_ERROR_OPEN, _pushmissing!, Int8Column, _error
-using SentinelArrays: SentinelArray, SentinelVector
+    READSTAT_ALIGNMENT_UNKNOWN, READSTAT_ERROR_OPEN, _error,
+    Int8Column, _pushmissing!, _pushchain!, _setntasks
+using SentinelArrays: SentinelArray, SentinelVector, ChainedVector
 using StructArrays: StructVector
 using Tables
 

--- a/test/table.jl
+++ b/test/table.jl
@@ -179,6 +179,22 @@ end
             @test tb[i] === columns[i]
         end
     end
+
+    columns, cols = gettestchainedcolumns(5)
+    N = 21
+    names = [Symbol("n",i) for i in 1:N]
+    hms = fill(true, N)
+    ms = StructVector{ReadStatColMeta}((["v$i" for i in 1:N], fill("%tf", N),
+        fill(READSTAT_TYPE_DOUBLE, N), fill(Symbol(), N), fill(Csize_t(1), N),
+        fill(Cint(1), N), fill(READSTAT_MEASURE_UNKNOWN, N),
+        fill(READSTAT_ALIGNMENT_UNKNOWN, N)))
+    tb = ReadStatTable(cols, names, vls, hms, m, ms)
+    for i in 1:N
+        if i in 2:2:10 || 11 < i < 14
+            @test ismissing(tb[1,i])
+        end
+        @test tb[i] === columns[i]
+    end
 end
 
 @testset "metadata colmetadata" begin

--- a/test/table.jl
+++ b/test/table.jl
@@ -181,7 +181,7 @@ end
     end
 
     columns, cols = gettestchainedcolumns(5)
-    N = 21
+    N = 23
     names = [Symbol("n",i) for i in 1:N]
     hms = fill(true, N)
     ms = StructVector{ReadStatColMeta}((["v$i" for i in 1:N], fill("%tf", N),
@@ -190,7 +190,7 @@ end
         fill(READSTAT_ALIGNMENT_UNKNOWN, N)))
     tb = ReadStatTable(cols, names, vls, hms, m, ms)
     for i in 1:N
-        if i in 2:2:10 || 11 < i < 14
+        if i in 2:2:14
             @test ismissing(tb[1,i])
         end
         @test tb[i] === columns[i]
@@ -199,7 +199,7 @@ end
     @test typeof(sch).parameters[2] == Tuple{String, Union{Int8, Missing}, Int8,
         Union{Int16, Missing}, Int16, Union{Int32, Missing}, Int32,
         Union{Float32, Missing}, Float32, Union{Float64, Missing}, Float64,
-        Union{Date, Missing}, Union{DateTime, Missing},
+        Union{Date, Missing}, Date, Union{DateTime, Missing}, DateTime,
         String, String3, String7, String15, String31, String63, String127, String255}
 end
 

--- a/test/table.jl
+++ b/test/table.jl
@@ -195,6 +195,12 @@ end
         end
         @test tb[i] === columns[i]
     end
+    sch = Tables.schema(tb)
+    @test typeof(sch).parameters[2] == Tuple{String, Union{Int8, Missing}, Int8,
+        Union{Int16, Missing}, Int16, Union{Int32, Missing}, Int32,
+        Union{Float32, Missing}, Float32, Union{Float64, Missing}, Float64,
+        Union{Date, Missing}, Union{DateTime, Missing},
+        String, String3, String7, String15, String31, String63, String127, String255}
 end
 
 @testset "metadata colmetadata" begin


### PR DESCRIPTION
For `.dta`, `.sas7bdat` and `.sav` formats, multiple threads are used by default unless the data file is small.