### PR TITLE
Change default metadata styles

### DIFF
--- a/docs/src/man/date-and-time-values.md
+++ b/docs/src/man/date-and-time-values.md
@@ -1,26 +1,26 @@
 # Date and Time Values
 
 Date and time values in the data files are recognized based on
-the variable format for each variable.
-For Stata, all date/time formats except `%tC` and `%d` are supported.[^1]
+the format of each variable.
+Most data/time formats can be recognized without user intervention.[^1]
 In case certain date/time formats are not recognized,
 they can be added easily.
 
 ## Translating Date and Time Values
 
-For all date/time formats from the statistical software,
-the date and time values are always stored as the numbers of periods
-passed since a reference date or time point chosen by the software.
-Therefore, knowing the reference data/time (epoch) and the length of a single period
+For all date/time formats from Stata, SAS and SPSS,
+the date and time values are stored as the numbers of periods elapsed
+since a reference date or time point (epoch) chosen by the software.
+Therefore, knowing the reference data/time and the length of a single period
 is sufficient for uncovering the represented date/time values for a given format.
 
 The full lists of recognized date/time formats for the statistical software
 are stored as dictionary keys;
 while the associated values are tuples of reference date/time and period length.[^2]
-If a variable is in a date/time format that is contained in the dictionary keys,
+If a variable is in a date/time format that can be found in the dictionary,
 [`readstat`](@ref) will handle the conversion to a Julia time type
 (unless the `convert_datetime` option prevents it).
-Otherwise, if a date/time format is not found in the dictionary keys,
+Otherwise, if a date/time format is not found in the dictionary,
 no type conversion will be attempted.
 Additional formats may be added by inserting key-value pairs to the relevant dictionaries.
 
@@ -34,7 +34,7 @@ ReadStatTables.sas_dt_formats["MMDDYY"]
 ReadStatTables.spss_dt_formats["TIME"]
 ```
 
-The translation of the date/time values into a Julia time type is handled by
+Translation of the date/time values into a Julia time type is handled by
 `parse_datetime`, which is not exported.
 
 ```@docs
@@ -43,6 +43,7 @@ ReadStatTables.parse_datetime
 
 [^1]:
 
+    For Stata, all date/time formats except `%tC` and `%d` are supported.
     The only difference between the `%tC` format and the `%tc` format
     is that `%tC` takes into account leap seconds while `%tc` does not.
     Since the `DateTime` type in the

--- a/docs/src/man/metadata.md
+++ b/docs/src/man/metadata.md
@@ -141,9 +141,9 @@ are able to recognize the metadata contained in `ReadStatTable`.
 
 By default, metadata on labels and notes have the `:note` style;
 all other metadata have the `:default` style.
-Key-value pairs of user-specified metadata styles,
+Keys for metadata with user-specified styles,
 along with those that have the `:note` style by default,
-are recorded in a `Dict` based on the keys of metadata:
+are recorded in a dictionary:
 
 ```@repl meta
 metastyle(tb)

--- a/docs/src/man/metadata.md
+++ b/docs/src/man/metadata.md
@@ -43,7 +43,7 @@ Metadata contained in a `ReadStatMeta` can be modified,
 optionally with a metadata style set at the same time:
 
 ```@repl meta
-metadata!(tb, "file_label", "A file label", style=:note)
+metadata!(tb, "file_label", "A file label", style=:default)
 ```
 
 Since `ReadStatMeta` has a dictionary-like interface,
@@ -88,7 +88,7 @@ Metadata contained in a `ReadStatColMeta` can be modified,
 optionally with a metadata style set at the same time:
 
 ```@repl meta
-colmetadata!(tb, :mylabl, "label", "A variable label", style=:note)
+colmetadata!(tb, :mylabl, "label", "A variable label", style=:default)
 ```
 
 A `ReadStatColMeta` also has a dictionary-like interface:
@@ -139,8 +139,10 @@ Packages that implement metadata-related methods compatible with
 [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)
 are able to recognize the metadata contained in `ReadStatTable`.
 
-By default, all metadata have the `:default` style.
-The user-specified metadata styles
+By default, metadata on labels and notes have the `:note` style;
+all other metadata have the `:default` style.
+Key-value pairs of user-specified metadata styles,
+along with those that have the `:note` style by default,
 are recorded in a `Dict` based on the keys of metadata:
 
 ```@repl meta
@@ -160,7 +162,7 @@ metadata associated with the same key always have the same style
 and hence are not distinguished across different columns.
 
 ```@repl meta
-metastyle!(tb, "label", :note)
+metastyle!(tb, "label", :default)
 colmetadata(tb, :mychar, "label", style=true)
 colmetadata(tb, :mynum, "label", style=true)
 ```

--- a/docs/src/man/table-interface.md
+++ b/docs/src/man/table-interface.md
@@ -60,7 +60,7 @@ end
 
 In addition to retrieving the data columns,
 it is possible to directly retrieve and modify individual data values
-via `getindex` and `setindex!`.
+via `getindex` and `setindex!`:
 
 ```@repl table
 tb[1,1]

--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -35,7 +35,7 @@ from a supported data file located at `filepath`.
 - `usecols::Union{ColumnSelector, Nothing} = nothing`: only collect data from the specified columns (variables); collect all columns if `usecols=nothing`.
 - `row_limit::Union{Integer, Nothing} = nothing`: restrict the total number of rows to be read; read all rows if `row_limit=nothing`.
 - `row_offset::Integer = 0`: skip the specified number of rows.
-- `ntasks::Union{Integer, Nothing} = nothing`: number of tasks spawned to read the data file in concurrent chunks with multiple threads; with `ntasks` being `nothing` or smaller than 1, select a default value based on the size of data file and the number of threads available (`Threads.nthreads()`); not applicable to `.xpt` and `.por` files where row count is unknown from metadata.
+- `ntasks::Union{Integer, Nothing} = nothing`: number of tasks spawned to read data file in concurrent chunks with multiple threads; with `ntasks` being `nothing` or smaller than 1, select a default value based on the size of data file and the number of threads available (`Threads.nthreads()`); not applicable to `.xpt` and `.por` files where row count is unknown from metadata.
 - `convert_datetime::Bool = true`: convert data from any column with a recognized date/time format to `Date` or `DateTime`.
 - `inlinestring_width::Integer = ext ∈ (".sav", ".por") ? 0 : 32`: use a fixed-width string type that can be stored inline for any string variable with width below `inlinestring_width` and `pool_width`; a non-positive value avoids using any inline string type; not recommended for SPSS files.
 - `pool_width::Integer = 64`: only attempt to use `PooledArray` for string variables with width of at least 64.

--- a/src/table.jl
+++ b/src/table.jl
@@ -155,6 +155,9 @@ const ColMetaVec = StructVector{ReadStatColMeta, NamedTuple{(:label, :format, :t
     Vector{UInt64}, Vector{Int32}, Vector{readstat_measure_t},
     Vector{readstat_alignment_t}}}, Int64}
 
+_default_metastyles() =
+    Dict{Symbol, Symbol}([:file_label, :notes, :label, :vallabel].=>:note)
+
 """
     ReadStatTable{Cols} <: Tables.AbstractColumns
 
@@ -184,7 +187,7 @@ struct ReadStatTable{Cols} <: Tables.AbstractColumns
         meta = ReadStatMeta()
         colmeta = StructVector{ReadStatColMeta}((String[], String[], readstat_type_t[],
             Symbol[], Csize_t[], Cint[], readstat_measure_t[], readstat_alignment_t[]))
-        styles = Dict{Symbol, Symbol}()
+        styles = _default_metastyles()
         return new{ReadStatColumns}(columns, names, lookup, vallabels, hasmissing, meta, colmeta, styles)
     end
     function ReadStatTable(
@@ -192,7 +195,7 @@ struct ReadStatTable{Cols} <: Tables.AbstractColumns
             names::Vector{Symbol},
             vallabels::Dict{Symbol, Dict}, hasmissing::Vector{Bool},
             meta::ReadStatMeta, colmeta::ColMetaVec,
-            styles::Dict{Symbol, Symbol}=Dict{Symbol, Symbol}())
+            styles::Dict{Symbol, Symbol} = _default_metastyles())
         lookup = Dict{Symbol, Int}(n=>i for (i, n) in enumerate(names))
         N = length(columns)
         length(lookup) == N ||
@@ -408,7 +411,8 @@ colmetadatasupport(::Type{<:ReadStatTable}) = (read=true, write=true)
 
 Return the specified style(s) of all metadata for table `tb`.
 If a metadata `key` is specified, only the style for the associated metadata are returned.
-By default, the style for all metadata is `:default`.
+By default, metadata on labels and notes have the `:note` style;
+all other metadata have the `:default` style.
 
 The style of metadata is only determined by `key` and hence
 is not distinguished across different columns.

--- a/test/table.jl
+++ b/test/table.jl
@@ -221,22 +221,22 @@ end
         [READSTAT_ALIGNMENT_UNKNOWN,READSTAT_ALIGNMENT_UNKNOWN]))
     tb = ReadStatTable(cols, names, vls, hms, m, ms)
 
-    @test isempty(metastyle(tb))
-    @test metastyle(tb, :file_label) == :default
-    @test metastyle(tb, "file_label") == :default
+    @test length(metastyle(tb)) == 4
+    @test metastyle(tb, :file_label) == :note
+    @test metastyle(tb, "file_label") == :note
 
     @test metadata(tb, "file_label") == "flabel"
     @test metadata(tb, :file_label) == "flabel"
-    @test metadata(tb, "file_label", style=true) == ("flabel", :default)
-
-    metastyle!(tb, "file_label", :note)
-    @test metastyle(tb, :file_label) == :note
     @test metadata(tb, "file_label", style=true) == ("flabel", :note)
+
+    metastyle!(tb, "file_label", :default)
+    @test metastyle(tb, :file_label) == :default
+    @test metadata(tb, "file_label", style=true) == ("flabel", :default)
 
     @test metadata(tb) === m
     v = metadata(tb, style=true)
     @test v isa AbstractDict
-    @test v["file_label"] == ("flabel", :note)
+    @test v["file_label"] == ("flabel", :default)
     @test length(v) == length(m)
     @test copy(v) isa Dict{String, Any}
 
@@ -244,22 +244,22 @@ end
 
     metadata!(tb, "file_label", "filelab")
     @test m.file_label == "filelab"
-    @test metastyle(tb, :file_label) == :note
-    metadata!(tb, "file_label", "flabel", style=:default)
-    @test m.file_label == "flabel"
     @test metastyle(tb, :file_label) == :default
+    metadata!(tb, "file_label", "flabel", style=:note)
+    @test m.file_label == "flabel"
+    @test metastyle(tb, :file_label) == :note
 
     @test colmetadata(tb, :c1, "label") == "v1"
-    @test colmetadata(tb, :c1, "label", style=true) == ("v1", :default)
+    @test colmetadata(tb, :c1, "label", style=true) == ("v1", :note)
     @test colmetadata(tb, :c1) == ms[1]
 
-    metastyle!(tb, "label", :note)
-    @test metastyle(tb, :label) == :note
-    @test colmetadata(tb, :c1, "label", style=true) == ("v1", :note)
+    metastyle!(tb, "label", :default)
+    @test metastyle(tb, :label) == :default
+    @test colmetadata(tb, :c1, "label", style=true) == ("v1", :default)
 
     v = colmetadata(tb, :c1, style=true)
     @test v isa AbstractDict
-    @test v["label"] == ("v1", :note)
+    @test v["label"] == ("v1", :default)
     @test length(v) == length(ms[1])
 
     d = colmetadata(tb)
@@ -286,10 +286,10 @@ end
 
     colmetadata!(tb, :c1, "label", "lab")
     @test ms.label[1] == "lab"
-    @test metastyle(tb, :label) == :note
-    colmetadata!(tb, :c1, "label", "v1", style=:default)
-    @test ms.label[1] == "v1"
     @test metastyle(tb, :label) == :default
+    colmetadata!(tb, :c1, "label", "v1", style=:note)
+    @test ms.label[1] == "v1"
+    @test metastyle(tb, :label) == :note
 
     lbls = colmetavalues(tb, "label")
     @test lbls == ["v1","v2"]


### PR DESCRIPTION
By default, metadata on labels and notes have the `:note` style; all other metadata have the `:default` style.