### PR TITLE
Add experimental write support for Tables.jl-compatible tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build
 docs/site
 *Manifest.toml
 *temp*
+data/sample_write_test*

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ docs/build
 docs/site
 *Manifest.toml
 *temp*
-data/sample_write_test*
+data/*write*

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -55,5 +55,7 @@ include("columns.jl")
 include("table.jl")
 include("parser.jl")
 include("readstat.jl")
+include("writer.jl")
+include("writestat.jl")
 
 end

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -46,7 +46,9 @@ export LabeledValue,
 
        readstat,
        readstatmeta,
-       readstatallmeta
+       readstatallmeta,
+
+       writestat
 
 include("wrappers.jl")
 include("LabeledArrays.jl")

--- a/src/table.jl
+++ b/src/table.jl
@@ -114,9 +114,12 @@ struct ReadStatColMeta <: AbstractMetaDict
     alignment::readstat_alignment_t
 end
 
-ReadStatColMetaVec() =
-    StructVector{ReadStatColMeta}((String[], String[], readstat_type_t[],
+function ReadStatColMetaVec(N::Integer = 0)
+    colmeta = StructVector{ReadStatColMeta}((String[], String[], readstat_type_t[],
         Symbol[], Csize_t[], Cint[], readstat_measure_t[], readstat_alignment_t[]))
+    N > 0 && resize!(colmeta, N)
+    return colmeta
+end
 
 function Base.show(io::IO, m::ReadStatColMeta)
     print(io, typeof(m).name.name, "(")

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -281,59 +281,133 @@ set_row_offset(parser::Ptr{Cvoid}, row_offset::Integer) =
     ccall((:readstat_set_row_offset, libreadstat),
         readstat_error_t, (Ptr{Cvoid}, Clong), parser, row_offset)
 
-begin_row(writer) =
-    ccall((:readstat_begin_row, libreadstat), Int, (Ptr{Cvoid},), writer)
-
-end_row(writer) =
-    ccall((:readstat_end_row, libreadstat), Int, (Ptr{Cvoid},), writer)
-
-begin_writing(writer, ::Val{:dta}, io, row_count) =
-    ccall((:readstat_begin_writing_dta, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
-
-begin_writing(writer, ::Val{:sav}, io, row_count) =
-    ccall((:readstat_begin_writing_sav, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
-
-begin_writing(writer, ::Val{:por}, io, row_count) =
-    ccall((:readstat_begin_writing_por, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
-
-begin_writing(writer, ::Val{:sas7bdat}, io, row_count) =
-    ccall((:readstat_begin_writing_sas7bdat, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
-
-begin_writing(writer, ::Val{:xport}, io, row_count) =
-    ccall((:readstat_begin_writing_xport, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
-
-insert_double_value(writer, variable, value) =
-    ccall((:readstat_insert_double_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cdouble), writer, variable, value)
-
-insert_float_value(writer, variable, value) =
-    ccall((:readstat_insert_float_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cfloat), writer, variable, value)
-
-insert_int32_value(writer, variable, value) =
-    ccall((:readstat_insert_int32_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, variable, value)
-
-insert_int16_value(writer, variable, value) =
-    ccall((:readstat_insert_int16_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cshort), writer, variable, value)
-
-insert_int8_value(writer, variable, value) =
-    ccall((:readstat_insert_int8_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cchar), writer, variable, value)
-
-insert_string_value(writer, variable, value) =
-    ccall((:readstat_insert_string_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring), writer, variable, value)
-
-insert_missing_value(writer, variable) =
-    ccall((:readstat_insert_missing_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}), writer, variable)
-
-add_variable(writer, name, type, width) =
-    ccall((:readstat_add_variable, libreadstat), Ptr{Cvoid}, (Ptr{Cvoid}, Cstring, Cint, Cint), writer, name, type, width)
-
 writer_init() = ccall((:readstat_writer_init, libreadstat), Ptr{Cvoid}, ())
 
-set_data_writer(writer, write_bytes) =
-    ccall((:readstat_set_data_writer, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}), writer, write_bytes)
+set_data_writer(writer::Ptr{Cvoid}, data_writer::Ptr{Cvoid}) =
+    ccall((:readstat_set_data_writer, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}), writer, data_writer)
 
-writer_set_file_label(writer, filelabel) =
-    ccall((:readstat_writer_set_file_label, libreadstat), Cvoid, (Ptr{Cvoid}, Cstring), writer, filelabel)
+add_label_set(writer::Ptr{Cvoid}, type::readstat_type_t, name::AbstractString) =
+    ccall((:readstat_add_label_set, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}), writer, data_writer)
 
-end_writing(writer) = ccall((:readstat_end_writing, libreadstat), Int, (Ptr{Cvoid},), writer)
+label_double_value(label_set::Ptr{Cvoid}, value::Real, label::AbstractString) =
+    ccall((:readstat_label_double_value, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Cdouble, Cstring), label_set, value, label)
 
-writer_free(writer) = ccall((:readstat_writer_free, libreadstat), Cvoid, (Ptr{Cvoid},), writer)
+label_int32_value(label_set::Ptr{Cvoid}, value::Integer, label::AbstractString) =
+    ccall((:readstat_label_int32_value, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Int32, Cstring), label_set, value, label)
+
+label_tagged_value(label_set::Ptr{Cvoid}, tag::Char, label::AbstractString) =
+    ccall((:readstat_label_tagged_value, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Cchar, Cstring), label_set, tag, label)
+
+add_variable(writer::Ptr{Cvoid}, name::AbstractString, type::readstat_type_t, storage_width::Integer) =
+    ccall((:readstat_add_variable, libreadstat), Ptr{Cvoid},
+        (Ptr{Cvoid}, Cstring, readstat_type_t, Csize_t), writer, name, type, storage_width)
+
+variable_set_label(variable::Ptr{Cvoid}, label::AbstractString) =
+    ccall((:readstat_variable_set_label, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Cstring), variable, label)
+
+variable_set_format(variable::Ptr{Cvoid}, format::AbstractString) =
+    ccall((:readstat_variable_set_format, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Cstring), variable, format)
+
+variable_set_label_set(variable::Ptr{Cvoid}, label_set::Ptr{Cvoid}) =
+    ccall((:readstat_variable_set_label_set, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), variable, label_set)
+
+variable_set_measure(variable::Ptr{Cvoid}, measure::readstat_measure_t) =
+    ccall((:readstat_variable_set_measure, libreadstat),
+        Cvoid, (Ptr{Cvoid}, readstat_measure_t), variable, measure)
+
+variable_set_alignment(variable::Ptr{Cvoid}, alignment::readstat_alignment_t) =
+    ccall((:readstat_variable_set_alignment, libreadstat),
+        Cvoid, (Ptr{Cvoid}, readstat_alignment_t), variable, alignment)
+
+variable_set_display_width(variable::Ptr{Cvoid}, display_width::Integer) =
+    ccall((:readstat_variable_set_display_width, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Cint), variable, display_width)
+
+get_variable(writer::Ptr{Cvoid}, index::Integer) =
+    ccall((:readstat_get_variable, libreadstat),
+        Ptr{Cvoid}, (Ptr{Cvoid}, Cint), writer, index)
+
+add_note(writer::Ptr{Cvoid}, note::AbstractString) =
+    ccall((:readstat_add_note, libreadstat),
+        Cvoid, (Ptr{Cvoid}, Cstring), writer, note)
+
+writer_set_file_label(writer::Ptr{Cvoid}, file_label::AbstractString) =
+    ccall((:readstat_writer_set_file_label, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Cstring), writer, file_label)
+
+writer_set_file_timestamp(writer::Ptr{Cvoid}, timestamp::DateTime) =
+    ccall((:readstat_writer_set_file_timestamp, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, UInt), writer, datetime2unix(timestamp))
+
+writer_set_file_format_version(writer::Ptr{Cvoid}, file_format_version::Integer) =
+    ccall((:readstat_writer_set_file_format_version, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, UInt8), writer, file_format_version)
+
+writer_set_table_name(writer::Ptr{Cvoid}, table_name::AbstractString) =
+    ccall((:readstat_writer_set_table_name, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Cstring), writer, table_name)
+
+writer_set_file_format_is_64bit(writer::Ptr{Cvoid}, is_64bit::Bool) =
+    ccall((:readstat_writer_set_file_format_is_64bit, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Cint), writer, is_64bit)
+
+writer_set_compression(writer::Ptr{Cvoid}, compression::readstat_compress_t) =
+    ccall((:readstat_writer_set_compression, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, readstat_compress_t), writer, compression)
+
+for ext in (:dta, :sav, :por, :sas7bdat, :xport)
+    begin_writing = Symbol(:begin_writing_, ext)
+    readstat_begin_writing = QuoteNode(Symbol(:readstat_begin_writing_, ext))
+    @eval begin $begin_writing(writer::Ptr{Cvoid}, user_ctx::Ref{Cvoid},
+        row_count::Integer) = ccall(($readstat_parse_ext, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ref{Cvoid}, Clong), writer, user_ctx, row_count)
+    end
+end
+
+begin_row(writer::Ptr{Cvoid}) =
+    ccall((:readstat_begin_row, libreadstat), readstat_error_t, (Ptr{Cvoid},), writer)
+
+insert_int8_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}, value::Int8) =
+    ccall((:readstat_insert_int8_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}, Cchar), writer, variable, value)
+
+insert_int16_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}, value::Int16) =
+    ccall((:readstat_insert_int16_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}, Cshort), writer, variable, value)
+
+insert_int32_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}, value::Int32) =
+    ccall((:readstat_insert_int32_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, variable, value)
+
+insert_float_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}, value::Float32) =
+    ccall((:readstat_insert_float_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}, Cfloat), writer, variable, value)
+
+insert_double_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}, value::Float64) =
+    ccall((:readstat_insert_double_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}, Cdouble), writer, variable, value)
+
+insert_string_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}, value::AbstractString) =
+    ccall((:readstat_insert_string_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring), writer, variable, value)
+
+insert_missing_value(writer::Ptr{Cvoid}, variable::Ptr{Cvoid}) =
+    ccall((:readstat_insert_missing_value, libreadstat),
+        readstat_error_t, (Ptr{Cvoid}, Ptr{Cvoid}), writer, variable)
+
+end_row(writer::Ptr{Cvoid}) =
+    ccall((:readstat_end_row, libreadstat), readstat_error_t, (Ptr{Cvoid},), writer)
+
+end_writing(writer::Ptr{Cvoid}) =
+    ccall((:readstat_end_writing, libreadstat), readstat_error_t, (Ptr{Cvoid},), writer)
+
+writer_free(writer::Ptr{Cvoid}) =
+    ccall((:readstat_writer_free, libreadstat), Cvoid, (Ptr{Cvoid},), writer)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -280,3 +280,60 @@ set_row_limit(parser::Ptr{Cvoid}, row_limit::Integer) =
 set_row_offset(parser::Ptr{Cvoid}, row_offset::Integer) =
     ccall((:readstat_set_row_offset, libreadstat),
         readstat_error_t, (Ptr{Cvoid}, Clong), parser, row_offset)
+
+begin_row(writer) =
+    ccall((:readstat_begin_row, libreadstat), Int, (Ptr{Cvoid},), writer)
+
+end_row(writer) =
+    ccall((:readstat_end_row, libreadstat), Int, (Ptr{Cvoid},), writer)
+
+begin_writing(writer, ::Val{:dta}, io, row_count) =
+    ccall((:readstat_begin_writing_dta, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
+
+begin_writing(writer, ::Val{:sav}, io, row_count) =
+    ccall((:readstat_begin_writing_sav, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
+
+begin_writing(writer, ::Val{:por}, io, row_count) =
+    ccall((:readstat_begin_writing_por, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
+
+begin_writing(writer, ::Val{:sas7bdat}, io, row_count) =
+    ccall((:readstat_begin_writing_sas7bdat, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
+
+begin_writing(writer, ::Val{:xport}, io, row_count) =
+    ccall((:readstat_begin_writing_xport, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, pointer_from_objref(io), Cint(row_count))
+
+insert_double_value(writer, variable, value) =
+    ccall((:readstat_insert_double_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cdouble), writer, variable, value)
+
+insert_float_value(writer, variable, value) =
+    ccall((:readstat_insert_float_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cfloat), writer, variable, value)
+
+insert_int32_value(writer, variable, value) =
+    ccall((:readstat_insert_int32_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cint), writer, variable, value)
+
+insert_int16_value(writer, variable, value) =
+    ccall((:readstat_insert_int16_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cshort), writer, variable, value)
+
+insert_int8_value(writer, variable, value) =
+    ccall((:readstat_insert_int8_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cchar), writer, variable, value)
+
+insert_string_value(writer, variable, value) =
+    ccall((:readstat_insert_string_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring), writer, variable, value)
+
+insert_missing_value(writer, variable) =
+    ccall((:readstat_insert_missing_value, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}), writer, variable)
+
+add_variable(writer, name, type, width) =
+    ccall((:readstat_add_variable, libreadstat), Ptr{Cvoid}, (Ptr{Cvoid}, Cstring, Cint, Cint), writer, name, type, width)
+
+writer_init() = ccall((:readstat_writer_init, libreadstat), Ptr{Cvoid}, ())
+
+set_data_writer(writer, write_bytes) =
+    ccall((:readstat_set_data_writer, libreadstat), Int, (Ptr{Cvoid}, Ptr{Cvoid}), writer, write_bytes)
+
+writer_set_file_label(writer, filelabel) =
+    ccall((:readstat_writer_set_file_label, libreadstat), Cvoid, (Ptr{Cvoid}, Cstring), writer, filelabel)
+
+end_writing(writer) = ccall((:readstat_end_writing, libreadstat), Int, (Ptr{Cvoid},), writer)
+
+writer_free(writer) = ccall((:readstat_writer_free, libreadstat), Cvoid, (Ptr{Cvoid},), writer)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1,0 +1,88 @@
+function handle_write!(data::Ptr{UInt8}, len::Cint, ctx::Ptr)
+    io = unsafe_pointer_to_objref(ctx) # restore io
+    actual_data = unsafe_wrap(Array{UInt8}, data, (len, )) # we may want to specify the type later
+    write(io, actual_data)
+    return len
+end
+
+function write_data_file(filename::AbstractString, filetype::Val, source; kwargs...) 
+    io = open(filename, "w")
+    write_data_file(filetype::Val, io, source; kwargs...)
+    close(io)
+end
+
+function write_data_file(filetype::Val, io::IO, source; filelabel = "")
+    writer = writer_init()
+    try
+        write_bytes = @cfunction(handle_write!, Cint, (Ptr{UInt8}, Cint, Ptr{Nothing}))
+        set_data_writer(writer, write_bytes)
+        writer_set_file_label(writer, filelabel)
+
+        rows = Tables.rows(source)
+        schema = Tables.schema(rows)
+        if schema === nothing
+            error("Could not determine table schema for data source.")
+        end
+        variables_array = []
+
+        variables_array = map(schema.names, schema.types) do column_name, column_type
+            readstat_type, storage_width = readstat_column_type_and_width(source, column_name, nonmissingtype(column_type))
+            return add_variable!(writer, column_name, readstat_type, storage_width)
+            # readstat_variable_set_label(variable, String(field)) TODO: label for a variable
+        end
+
+        begin_writing(writer, filetype, io, length(rows))
+
+        for row in rows
+            begin_row(writer)
+            Tables.eachcolumn(schema, row) do val, i, name
+                insert_value!(writer, variables_array[i], val)
+            end
+            end_row(writer)
+        end
+
+        end_writing(writer)
+    finally
+        writer_free(writer)
+    end
+end
+
+readstat_column_type_and_width(_, _, other_type) = error("Cannot handle column with element type $other_type. Is this type supported by ReadStat?")
+readstat_column_type_and_width(_, _, ::Type{Float64}) = READSTAT_TYPE_DOUBLE, 0
+readstat_column_type_and_width(_, _, ::Type{Float32}) = READSTAT_TYPE_FLOAT, 0
+readstat_column_type_and_width(_, _, ::Type{Int32}) = READSTAT_TYPE_INT32, 0
+readstat_column_type_and_width(_, _, ::Type{Int16}) = READSTAT_TYPE_INT16, 0
+readstat_column_type_and_width(_, _, ::Type{Int8}) = READSTAT_TYPE_CHAR, 0
+function readstat_column_type_and_width(source, colname, ::Type{String})
+    col = Tables.getcolumn(source, colname)
+    maxlen = maximum(col) do str
+        str === missing ? 0 : ncodeunits(str)
+    end
+    if maxlen >= 2045 # maximum length of normal strings
+        return READSTAT_TYPE_LONG_STRING, 0
+    else
+        return READSTAT_TYPE_STRING, maxlen
+    end
+end
+
+add_variable!(writer, name, type, width = 0) = add_variable(writer, name, type, width)
+
+insert_value!(writer, variable, value::Float64) = insert_double_value(writer, variable, value)
+insert_value!(writer, variable, value::Float32) = insert_float_value(writer, variable, value)
+insert_value!(writer, variable, ::Missing) = insert_missing_value(writer, variable)
+insert_value!(writer, variable, value::Int8) = insert_int8_value(writer, variable, value)
+insert_value!(writer, variable, value::Int16) = insert_int16_value(writer, variable, value)
+insert_value!(writer, variable, value::Int32) = insert_int32_value(writer, variable, value)
+insert_value!(writer, variable, value::AbstractString) = insert_string_value(writer, variable, value)
+
+read_dta(filename::AbstractString) = read_data_file(filename, Val(:dta))
+read_sav(filename::AbstractString) = read_data_file(filename, Val(:sav))
+read_por(filename::AbstractString) = read_data_file(filename, Val(:por))
+read_sas7bdat(filename::AbstractString) = read_data_file(filename, Val(:sas7bdat))
+read_xport(filename::AbstractString) = read_data_file(filename, Val(:xport))
+
+write_dta(filename::AbstractString, source; kwargs...) = write_data_file(filename, Val(:dta), source; kwargs...)
+write_sav(filename::AbstractString, source; kwargs...) = write_data_file(filename, Val(:sav), source; kwargs...)
+write_por(filename::AbstractString, source; kwargs...) = write_data_file(filename, Val(:por), source; kwargs...)
+write_sas7bdat(filename::AbstractString, source; kwargs...) = write_data_file(filename, Val(:sas7bdat), source; kwargs...)
+write_xport(filename::AbstractString, source; kwargs...) = write_data_file(filename, Val(:xport), source; kwargs...)

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -1,0 +1,132 @@
+const ext2writer = Dict{String, Any}(
+    ".dta" => begin_writing_dta,
+    ".sav" => begin_writing_sav,
+    ".por" => begin_writing_por,
+    ".sas7bdat" => begin_writing_sas7bdat,
+    ".xpt" => begin_writing_xport
+)
+
+# Default mapping from julia types to ReadStat types
+rstype(::Type{Int8}) = READSTAT_TYPE_INT8
+rstype(::Type{Int16}) = READSTAT_TYPE_INT16
+rstype(::Type{<:Integer}) = READSTAT_TYPE_INT32
+rstype(::Type{Float32}) = READSTAT_TYPE_Float
+rstype(::Type{<:Real}) = READSTAT_TYPE_DOUBLE
+rstype(::Type{<:AbstractString}) = READSTAT_TYPE_STRING
+rstype(type) = error("element type $type is not supported")
+
+# Stata .dta format before version 118 does not support Unicode for string variables
+const default_file_format_version = Dict{String, Int}(
+    ".dta" => 118,
+    ".xpt" => 5,
+    ".sav" => 2,
+)
+
+# Accepted maximum length for strings varies by the file format and version
+function _readstat_string_width(col)
+    if eltype(col) <: Union{InlineString, Missing}
+        return Csize_t(sizeof(col))
+    else
+        maxlen = maximum(col) do str
+            str === missing ? 0 : ncodeunits(str)
+        end
+        return Csize_t(maxlen)
+    end
+end
+
+function ReadStatTable(table, ext::AbstractString;
+        vallabels::Dict{Symbol, Dict} = Dict{Symbol, Dict}(),
+        hasmissing::Vector{Bool} = Vector{Bool}(),
+        meta::ReadStatMeta = ReadStatMeta(),
+        colmeta::ColMetaVec = ReadStatColMetaVec(),
+        styles::Dict{Symbol, Symbol} = _default_metastyles(),
+        kwargs...)
+    Tables.istable(table) && Tables.columnaccess(table) || throw(
+        ArgumentError("table of type $(typeof(table)) is not accepted"))
+    cols = Tables.columns(table)
+    names = map(Symbol, columnnames(cols))
+    N = length(names)
+    length(hasmissing) == N || (hasmissing = fill(true, N))
+    # Only overide the default values for fields relevant to writer behavior
+    meta.row_count = Tables.rowcount(cols)
+    meta.var_count = N
+    if ext != meta.file_ext
+        meta.file_ext = ext
+        meta.file_format_version = get(default_file_format_version, ext, -1)
+    end
+    if length(colmeta) != N
+        resize!(colmeta, N)
+        for i in 1:N
+            col = Tables.getcolumn(cols, i)
+            colmeta.label[i] = colmetadata(table, i, "label", "")
+            #! To do: handle format for DateTime columns
+            colmeta.format[i] = colmetadata(table, i, "format", "")
+            #! To do: ensure that an array of type such as CategoricalArray works
+            #! Consider constructing value labels for such arrays
+            type = rstype(nonmissingtype(eltype(refarray(col))))
+            colmeta.type[i] = colmetadata(table, i, "type", type)
+            lblname = colmetadata(table, i, "vallabel", Symbol())
+            colmeta.vallabel[i] = lblname
+            if col isa LabeledArrOrSubOrReshape
+                lbls = get(vallabels, lblname, nothing)
+                if lbls === nothing
+                    vallabels[lblname] = getvaluelabels(col)
+                elseif lbls != getvaluelabels(col)
+                    error("value label name $lblname is not unique")
+                end
+            end
+            if type === READSTAT_TYPE_STRING
+                width = _readstat_string_width(col)
+            elseif type === READSTAT_TYPE_DOUBLE
+                # Only needed for .xpt files
+                width = Csize_t(8)
+            else
+                width = Csize_t(0)
+            end
+            colmeta.storage_width[i] = width
+            colmeta.display_width[i] = max(Cint(width), Cint(8))
+            colmeta.measure[i] = READSTAT_MEASURE_UNKNOWN
+            colmeta.alignment[i] = READSTAT_ALIGNMENT_UNKNOWN
+        end
+    end
+    return ReadStatTable(cols, names, vallabels, hasmissing, meta, colmeta, styles)
+end
+
+function ReadStatTable(table::ReadStatTable{<:ColumnsOrChained}, ext::AbstractString;
+        update_width::Bool=true,
+        kwargs...)
+    meta = _meta(table)
+    meta.row_count = nrow(table)
+    meta.var_count = ncol(table)
+    if ext != meta.file_ext
+        meta.file_ext = ext
+        meta.file_format_version = get(default_file_format_version, ext, -1)
+    end
+    if update_width
+        for i in 1:ncol(table)
+            type = _colmeta(table, i, :type)
+            if type === READSTAT_TYPE_STRING
+                width = _readstat_string_width(col)
+            elseif type === READSTAT_TYPE_DOUBLE
+                # Only needed for .xpt files
+                width = Csize_t(8)
+            else
+                width = Csize_t(0)
+            end
+            colmeta.storage_width[i] = width
+        end
+    end
+    return table
+end
+
+function writestat(filepath, table;
+        ext = lowercase(splitext(filepath)[2]),
+        kwargs...)
+    filepath = string(filepath)
+    write_ext = get(ext2writer, ext, nothing)
+    write_ext === nothing && throw(ArgumentError("file extension $ext is not supported"))
+    tb = ReadStatTable(table, ext; kwargs...)
+    io = open(filepath, "w")
+    _write(io, ext, write_ext, tb)
+    return tb
+end

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -94,7 +94,7 @@ function ReadStatTable(table, ext::AbstractString;
     return ReadStatTable(cols, names, vallabels, hasmissing, meta, colmeta, styles)
 end
 
-function ReadStatTable(table::ReadStatTable{<:ColumnsOrChained}, ext::AbstractString;
+function ReadStatTable(table::ReadStatTable, ext::AbstractString;
         update_width::Bool=true,
         kwargs...)
     meta = _meta(table)

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -54,7 +54,9 @@ function ReadStatTable(table, ext::AbstractString;
         meta.file_ext = ext
         meta.file_format_version = get(default_file_format_version, ext, -1)
     end
-    if length(colmeta) != N
+    # Assume colmeta is manually specified if the length matches
+    # The metadata interface is absent before DataFrames.jl v1.4 which requires Julia v1.6
+    if length(colmeta) != N && colmetadatasupport(typeof(table)).read
         resize!(colmeta, N)
         for i in 1:N
             col = Tables.getcolumn(cols, i)

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -54,6 +54,12 @@ function ReadStatTable(table, ext::AbstractString;
         meta.file_ext = ext
         meta.file_format_version = get(default_file_format_version, ext, -1)
     end
+    # propagate the three label-like metadata attributes if present
+    if metadatasupport(typeof(table)).read
+        meta.notes = metadata(table, "notes", String[])
+        meta.file_label = metadata(table, "file_label", "")
+        meta.table_name = metadata(table, "table_name", "")
+    end
     # Assume colmeta is manually specified if the length matches
     # The metadata interface is absent before DataFrames.jl v1.4 which requires Julia v1.6
     if length(colmeta) != N && colmetadatasupport(typeof(table)).read

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -127,6 +127,46 @@ function ReadStatTable(table::ReadStatTable, ext::AbstractString;
     return table
 end
 
+"""
+    writestat(filepath, table; ext = lowercase(splitext(filepath)[2]), kwargs...)
+
+Write `table` to a file with extension `ext` located at `filepath`.
+
+The actual object being written out is `ReadStatTable(table, ext; kwargs...)`, so
+specific settings can be controlled with all the `kwargs` that this method supports.
+
+# Accepted File Extensions
+- Stata: `.dta`.
+- SAS: `.sas7bdat` and `.xpt`. (Note: There's a known issue with the underlying `ReadStat` C library that SAS currently cannot read the produced `.sas7bdat` files.)
+- SPSS: `.sav` and `por`.
+
+# Supported types
+
+The argument `table` can be any type compatible with the `Tables.jl` interface.
+Each file format supports a different set of column types:
+
+- Stata:
+    `Int8`, `Int16`, `Int32`, `Float32`, `Float64`, fixed-width strings from 1 to 2045 bytes or
+    arbitrary-length strings with a maximum size of 2,000,000,000 bytes.
+- SAS: TODO
+- SPSS: TODO
+
+# Metadata
+
+Table and column metadata is supported via the interface defined in `DataAPI.jl`.
+
+## Table metadata
+
+The main table metadata fields supported by ReadStatTables are:
+- `"notes"` (`Vector{String}`)
+- `"file_label"` (`String`)
+- `"table_name"` (`String`)
+These will be picked up from `table` automatically via `DataAPI.metadata(table, key)`.
+
+## Column metadata
+
+TODO
+"""
 function writestat(filepath, table;
         ext = lowercase(splitext(filepath)[2]),
         kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,10 @@ const tests = [
 
 printstyled("Running tests:\n", color=:blue, bold=true)
 
-@time for test in tests
-    include("$test.jl")
-    println("\033[1m\033[32mPASSED\033[0m: $(test)")
+@testset "ReadStatTables" verbose=true begin
+    for test in tests
+        @testset "$test" verbose=true begin
+            include("$test.jl")
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,13 @@ using Dates
 using InlineStrings
 using PooledArrays
 using ReadStatTables: error_message, READSTAT_COMPRESS_NONE, READSTAT_ENDIAN_NONE,
-    READSTAT_TYPE_INT8, READSTAT_TYPE_DOUBLE, READSTAT_MEASURE_UNKNOWN,
+    READSTAT_TYPE_INT8, READSTAT_TYPE_INT32, READSTAT_TYPE_DOUBLE, READSTAT_MEASURE_UNKNOWN,
     READSTAT_ALIGNMENT_UNKNOWN, READSTAT_ERROR_OPEN, _error,
-    Int8Column, _pushmissing!, _pushchain!, _setntasks
+    Int8Column, _pushmissing!, _pushchain!, _setntasks, rstype
 using SentinelArrays: SentinelArray, SentinelVector, ChainedVector
 using StructArrays: StructVector
 using Tables
+using Tables: getcolumn
 
 const tests = [
     "LabeledArrays",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,15 +19,13 @@ const tests = [
     "LabeledArrays",
     "columns",
     "table",
-    "readstat"
+    "readstat",
+    "writestat"
 ]
 
 printstyled("Running tests:\n", color=:blue, bold=true)
 
-@testset "ReadStatTables" verbose=true begin
-    for test in tests
-        @testset "$test" verbose=true begin
-            include("$test.jl")
-        end
-    end
+@time for test in tests
+    include("$test.jl")
+    println("\033[1m\033[32mPASSED\033[0m: $(test)")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,9 @@ const tests = [
 printstyled("Running tests:\n", color=:blue, bold=true)
 
 @time for test in tests
+    if VERSION < v"1.6" && test == "writestat"
+        continue
+    end
     include("$test.jl")
     println("\033[1m\033[32mPASSED\033[0m: $(test)")
 end

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -1,14 +1,44 @@
-@testset "writestat dta" begin
-    dta = "$(@__DIR__)/../data/sample.dta"
-    d = readstat(dta)
-    #out = writestat("$(@__DIR__)/../data/write.dta", d)
+extensions = ["dta", "por", "sav", "sas7bdat", "xpt"]
 
-    df = DataFrame(d)
-    # Drop the date/time columns as the conversion is not implemented yet
-    df2 = df[!,[:mychar, :mynum, :mylabl, :myord]]
-    if VERSION >= v"1.6"
-        out = writestat("$(@__DIR__)/../data/write_fallback.dta", df2)
-        @test typeof(out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
-        @test size(out) == size(df2)
+@testset "writestat" begin
+    @testset "writestat $ext" for ext in extensions
+        infile = "$(@__DIR__)/../data/sample.$ext"
+        rs_table = readstat(infile)
+
+        df_full = DataFrame(rs_table)
+
+        # Drop the date/time columns as the conversion is not implemented yet
+        selected_cols = if ext in ["por", "xpt"]
+            [:MYCHAR, :MYNUM, :MYLABL, :MYORD]
+        else
+            [:mychar, :mynum, :mylabl, :myord]
+        end
+        df = df_full[!,selected_cols]
+
+        outfile = "$(@__DIR__)/../data/sample_write_test.$ext"
+        rs_table_out = writestat(outfile, df)
+        @test typeof(rs_table_out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
+        
+        rs_table_read_back = readstat(outfile)
+
+        # check that specific table metadata is the same
+        @testset "metadata \"$key\"" for key in ["file_label", "notes"]
+            @test metadata(rs_table_out, key) == metadata(df, key)
+            @test metadata(rs_table_read_back, key) == metadata(df, key)
+        end
+
+        # # check that column metadata in the source dataframe can be found in the read back dataframe
+        # # this currently fails because some labels differ
+        # for name in names(df)
+        #     cm_df = colmetadata(df, name)
+        #     cm_rs = colmetadata(rs_table_read_back, name)
+        #     for (key, value) in cm_df
+        #         @test cm_rs[key] == value
+        #     end
+        # end
+
+        # check that data round-tripped correctly
+        df_read_back = DataFrame(rs_table_read_back)
+        @test isequal(df_read_back, df) # isequal returns true for missings and NaNs
     end
 end

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -1,44 +1,64 @@
+@testset "writestat dta" begin
+    alltypes = "$(@__DIR__)/../data/alltypes.dta"
+    dtype = readstat(alltypes)
+    tb = writestat("$(@__DIR__)/../data/write_alltypes.dta", dtype)
+    @test isequal(tb, dtype)
+    df = DataFrame(dtype)
+    tb2 = writestat("$(@__DIR__)/../data/write_df_alltypes.dta", dtype)
+    @test isequal(tb2, dtype)
+
+    stringtypes = "$(@__DIR__)/../data/stringtypes.dta"
+    strtype = readstat(stringtypes)
+    tb = writestat("$(@__DIR__)/../data/write_stringtypes.dta", strtype)
+    @test isequal(tb, strtype)
+    @test Int.(colmetavalues(tb, :storage_width)) ==
+        [3, 3, 7, 7, 15, 15, 31, 31, 32, 63, 64, 127, 128, 255, 256]
+    df = DataFrame(strtype)
+    tb2 = writestat("$(@__DIR__)/../data/write_df_stringtypes.dta", strtype)
+    @test Int.(colmetavalues(tb2, :storage_width)) ==
+        [3, 3, 7, 7, 15, 15, 31, 31, 32, 63, 64, 127, 128, 255, 256]
+    @test isequal(tb2, strtype)
+end
+
 extensions = ["dta", "por", "sav", "sas7bdat", "xpt"]
 
-@testset "writestat" begin
-    @testset "writestat $ext" for ext in extensions
-        infile = "$(@__DIR__)/../data/sample.$ext"
-        rs_table = readstat(infile)
+@testset "writestat roundtrip $ext" for ext in extensions
+    infile = "$(@__DIR__)/../data/sample.$ext"
+    rs_table = readstat(infile)
 
-        df_full = DataFrame(rs_table)
+    df_full = DataFrame(rs_table)
 
-        # Drop the date/time columns as the conversion is not implemented yet
-        selected_cols = if ext in ["por", "xpt"]
-            [:MYCHAR, :MYNUM, :MYLABL, :MYORD]
-        else
-            [:mychar, :mynum, :mylabl, :myord]
-        end
-        df = df_full[!,selected_cols]
-
-        outfile = "$(@__DIR__)/../data/sample_write_test.$ext"
-        rs_table_out = writestat(outfile, df)
-        @test typeof(rs_table_out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
-        
-        rs_table_read_back = readstat(outfile)
-
-        # check that specific table metadata is the same
-        @testset "metadata \"$key\"" for key in ["file_label", "notes"]
-            @test metadata(rs_table_out, key) == metadata(df, key)
-            @test metadata(rs_table_read_back, key) == metadata(df, key)
-        end
-
-        # # check that column metadata in the source dataframe can be found in the read back dataframe
-        # # this currently fails because some labels differ
-        # for name in names(df)
-        #     cm_df = colmetadata(df, name)
-        #     cm_rs = colmetadata(rs_table_read_back, name)
-        #     for (key, value) in cm_df
-        #         @test cm_rs[key] == value
-        #     end
-        # end
-
-        # check that data round-tripped correctly
-        df_read_back = DataFrame(rs_table_read_back)
-        @test isequal(df_read_back, df) # isequal returns true for missings and NaNs
+    # Drop the date/time columns as the conversion is not implemented yet
+    selected_cols = if ext in ["por", "xpt"]
+        [:MYCHAR, :MYNUM, :MYLABL, :MYORD]
+    else
+        [:mychar, :mynum, :mylabl, :myord]
     end
+    df = df_full[!,selected_cols]
+
+    outfile = "$(@__DIR__)/../data/sample_write_test.$ext"
+    rs_table_out = writestat(outfile, df)
+    @test typeof(rs_table_out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
+    
+    rs_table_read_back = readstat(outfile)
+
+    # check that specific table metadata is the same
+    @testset "metadata \"$key\"" for key in ["file_label", "notes"]
+        @test metadata(rs_table_out, key) == metadata(df, key)
+        @test metadata(rs_table_read_back, key) == metadata(df, key)
+    end
+
+    # # check that column metadata in the source dataframe can be found in the read back dataframe
+    # # this currently fails because some labels differ
+    # for name in names(df)
+    #     cm_df = colmetadata(df, name)
+    #     cm_rs = colmetadata(rs_table_read_back, name)
+    #     for (key, value) in cm_df
+    #         @test cm_rs[key] == value
+    #     end
+    # end
+
+    # check that data round-tripped correctly
+    df_read_back = DataFrame(rs_table_read_back)
+    @test isequal(df_read_back, df) # isequal returns true for missings and NaNs
 end

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -6,6 +6,8 @@
     df = DataFrame(d)
     # Drop the date/time columns as the conversion is not implemented yet
     df2 = df[!,[:mychar, :mynum, :mylabl, :myord]]
-    out = writestat("$(@__DIR__)/../data/write_fallback.dta", df2)
-    @test typeof(out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
+    if VERSION >= v"1.6"
+        out = writestat("$(@__DIR__)/../data/write_fallback.dta", df2)
+        @test typeof(out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
+    end
 end

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -1,0 +1,11 @@
+@testset "writestat dta" begin
+    dta = "$(@__DIR__)/../data/sample.dta"
+    d = readstat(dta)
+    #out = writestat("$(@__DIR__)/../data/write.dta", d)
+
+    df = DataFrame(d)
+    # Drop the date/time columns as the conversion is not implemented yet
+    df2 = df[!,[:mychar, :mynum, :mylabl, :myord]]
+    out = writestat("$(@__DIR__)/../data/write_fallback.dta", df2)
+    @test typeof(out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
+end

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -9,5 +9,6 @@
     if VERSION >= v"1.6"
         out = writestat("$(@__DIR__)/../data/write_fallback.dta", df2)
         @test typeof(out) == ReadStatTable{DataFrames.DataFrameColumns{DataFrame}}
+        @test size(out) == size(df2)
     end
 end


### PR DESCRIPTION
I've moved the PR from ReadStat over, slightly editing it so it fits this library's formatting better. But I haven't yet made any conceptual changes.

I think your suggestion from the issue to use ReadStatTable as the input type is good, because it might make it easiest to handle all metadata correctly. Most of the work would then move into conversion methods between tables.

The base method could call `convert(ReadStatTable, table)` or something to that effect, and if the user needs more control, they could handle conversion themselves.

I'm not sure yet, what the whole list of features is that should be supported, as the different file formats have different capabilities as far as I remember from months ago. Do you have an idea which metadata is most important? Do you ideally want to have lossless roundtripping for a read-write-read scenario?