### PR TITLE
Improve value label generation for `writestat` and update documentation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 ReadStatTables = "52522f7a-9570-4e34-8ac6-c005c74d4b84"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
 using Documenter
 using ReadStatTables
 using CategoricalArrays
+using PooledArrays
 
 DocMeta.setdocmeta!(ReadStatTables, :DocTestSetup, :(using ReadStatTables, CategoricalArrays))
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ Welcome to the documentation site for ReadStatTables.jl!
 
 [ReadStatTables.jl](https://github.com/junyuan-chen/ReadStatTables.jl)
 is a Julia package for reading and writing Stata, SAS and SPSS data files with
-a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible table.[^1]
+[Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables.[^1]
 It utilizes the [ReadStat](https://github.com/WizardMac/ReadStat) C library
 developed by [Evan Miller](https://www.evanmiller.org)
 for parsing and writing the data files.
@@ -30,11 +30,11 @@ based on the benchmark results
 ReadStatTables.jl provides the following features in addition to
 wrapping the C interface of ReadStat:
 
-- Fast multi-threaded data collection from ReadStat parsers to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible column table `ReadStatTable`.
-- Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl).
-- Integration of value labels into data columns via a custom array type `LabeledArray`.
-- Translation of date and time values into Julia time types `Date` and `DateTime`.
-- Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables (experimental).
+- Fast multi-threaded data collection from ReadStat parsers to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible `ReadStatTable`
+- Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)
+- Integration of value labels into data columns via a custom array type `LabeledArray`
+- Translation of date and time values into Julia time types `Date` and `DateTime`
+- Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables (experimental)
 
 ## Supported File Formats
 
@@ -59,9 +59,9 @@ pkg> add ReadStatTables
 The development of ReadStatTables.jl is not fully complete.
 The main limitations to be addressed are the following:
 
-- Read support of value labels for SAS files is temporarily absent.
+- Read support for SAS value labels is temporarily absent.
 - All missing values are represented by a single value `missing`.[^2]
-- Write support of the file formats is experimental and not fully developed.
+- Write support for the file formats is experimental and not fully developed.
 
 [^1]:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,11 +3,11 @@
 Welcome to the documentation site for ReadStatTables.jl!
 
 [ReadStatTables.jl](https://github.com/junyuan-chen/ReadStatTables.jl)
-is a Julia package for reading data files from Stata, SAS and SPSS into
-a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible table.
+is a Julia package for reading and writing Stata, SAS and SPSS data files with
+a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible table.[^1]
 It utilizes the [ReadStat](https://github.com/WizardMac/ReadStat) C library
 developed by [Evan Miller](https://www.evanmiller.org)
-for parsing the data files.
+for parsing and writing the data files.
 The same C library is also the backend of popular packages in other languages such as
 [pyreadstat](https://github.com/Roche/pyreadstat) for Python
 and [haven](https://github.com/tidyverse/haven) for R.
@@ -30,18 +30,19 @@ based on the benchmark results
 ReadStatTables.jl provides the following features in addition to
 wrapping the C interface of ReadStat:
 
-- Efficient data collection from ReadStat parser to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible column table `ReadStatTable`.
+- Fast multi-threaded data collection from ReadStat parsers to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible column table `ReadStatTable`.
 - Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl).
 - Integration of value labels into data columns via a custom array type `LabeledArray`.
 - Translation of date and time values into Julia time types `Date` and `DateTime`.
+- Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables (experimental).
 
 ## Supported File Formats
 
 ReadStatTables.jl recognizes data files with the following file extensions at this moment:
 
-- Stata: `.dta`.
-- SAS: `.sas7bdat` and `.xpt`.
-- SPSS: `.sav` and `.por`.
+- Stata: `.dta`
+- SAS: `.sas7bdat` and `.xpt`
+- SPSS: `.sav` and `.por`
 
 ## Installation
 
@@ -56,10 +57,22 @@ pkg> add ReadStatTables
 ## Known Limitations
 
 The development of ReadStatTables.jl is not fully complete.
-The main limitations are the following:
+The main limitations to be addressed are the following:
 
-- Read support of value labels for SAS files is absent.
-- All missing values are represented by a single value `missing`.[^1]
-- Write support of the file formats has not been implemented.
+- Read support of value labels for SAS files is temporarily absent.
+- All missing values are represented by a single value `missing`.[^2]
+- Write support of the file formats is experimental and not fully developed.
 
-[^1]: The statistical software may accept multiple values for representing missing values (e.g., `.a`, `.b`,..., `.z` in Stata). These original values can be recognized by the parser but are not integrated into the output at this moment.
+[^1]:
+
+    Development for the reading capability is temporarily prioritized over that
+    for the writing capability.
+    Implementation for the write support only started recently
+    and should be considered as experimental.
+
+[^2]:
+
+    The statistical software may accept multiple values for representing missing values
+    (e.g., `.a`, `.b`,..., `.z` in Stata).
+    These original values can be recognized by the parser
+    but are not integrated into the output at this moment.

--- a/docs/src/man/getting-started.md
+++ b/docs/src/man/getting-started.md
@@ -128,6 +128,42 @@ convertvalue(Int32, tb.mylabl)
 convertvalue
 ```
 
+## Writing a Data File
+
+To write a table to a supported data file format:
+
+```@repl getting-started
+# Create a data frame for illustration
+df = DataFrame(readstat("data/alltypes.dta")); emptycolmetadata!(df)
+out = writestat("data/write_alltypes.dta", df)
+```
+
+The returned table `out` contains the actual data (including metadata)
+that are exposed to the writer.
+
+Value labels attached to a `LabeledArray` are always preserved in the output file.
+If the input table contains any column of type `CategoricalArray` or `PooledArray`,
+value labels are created and written automatically by default:
+
+```@repl getting-started
+using PooledArrays
+df[!,:vbyte] = CategoricalArray(valuelabels(df.vbyte))
+df[!,:vint] = PooledArray(valuelabels(df.vint))
+out = writestat("data/write_alltypes.dta", df)
+```
+
+Notice that in the returned table, the columns `vbyte` and `vint` are `LabeledArray`s:
+
+```@repl getting-started
+out.vbyte
+out.vint
+```
+
+!!! warning
+
+    The write support is experimental and not fully developed.
+    Caution should be taken when writing the data files.
+
 ## More Options
 
 The behavior of `readstat` can be adjusted by passing keyword arguments:
@@ -150,8 +186,18 @@ readstatmeta
 ```
 
 To additionally collect variable-level metadata and all value labels:
+
 ```@docs
 readstatallmeta
+```
+
+For writing tables to data files,
+one may gain more control by first converting a table to a `ReadStatTable`:
+
+```@docs
+writestat
+ReadStatTable(table, ext::AbstractString; kwargs...)
+ReadStatTable(table::ReadStatTable, ext::AbstractString; kwargs...)
 ```
 
 [^1]: The printed output is generated with [PrettyTables.jl](https://github.com/ronisbr/PrettyTables.jl).

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -1,6 +1,7 @@
 module ReadStatTables
 
 using CEnum: @cenum
+using DataAPI: refpool
 using Dates
 using Dates: unix2datetime
 using InlineStrings

--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -19,16 +19,19 @@ function _setntasks(ncells::Integer)
     end
 end
 
+const _supported_formats_str = """
+    # Supported File Formats
+    - Stata: `.dta`
+    - SAS: `.sas7bdat` and `.xpt`
+    - SPSS: `.sav` and `por`"""
+
 """
     readstat(filepath; kwargs...)
 
 Return a [`ReadStatTable`](@ref) that collects data (including metadata)
 from a supported data file located at `filepath`.
 
-# Accepted File Extensions
-- Stata: `.dta`.
-- SAS: `.sas7bdat` and `.xpt`.
-- SPSS: `.sav` and `por`.
+$_supported_formats_str
 
 # Keywords
 - `ext = lowercase(splitext(filepath)[2])`: extension of data file for choosing the parser.
@@ -189,10 +192,7 @@ without reading the full data
 from a supported data file located at `filepath`.
 See also [`readstatallmeta`](@ref).
 
-# Accepted File Extensions
-- Stata: `.dta`.
-- SAS: `.sas7bdat` and `.xpt`.
-- SPSS: `.sav` and `por`.
+$_supported_formats_str
 
 # Keywords
 - `ext = lowercase(splitext(filepath)[2])`: extension of data file for choosing the parser.
@@ -232,10 +232,7 @@ The four returned objects are for file-level metadata,
 variable names, variable-level metadata and value labels respectively.
 See also [`readstatmeta`](@ref).
 
-# Accepted File Extensions
-- Stata: `.dta`.
-- SAS: `.sas7bdat` and `.xpt`.
-- SPSS: `.sav` and `por`.
+$_supported_formats_str
 
 # Keywords
 - `ext = lowercase(splitext(filepath)[2])`: extension of data file for choosing the parser.

--- a/src/table.jl
+++ b/src/table.jl
@@ -168,12 +168,15 @@ _default_metastyles() =
 """
     ReadStatTable{Cols} <: Tables.AbstractColumns
 
-A `Tables.jl`-compatible column table that efficiently collects data
-from a Stata, SAS or SPSS file processed with the `ReadStat` C library.
+A `Tables.jl`-compatible column table that collects data read from or written to
+a Stata, SAS or SPSS file processed with the `ReadStat` C library.
 File-level and variable-level metadata can be retrieved and modified
 via methods compatible with `DataAPI.jl`.
+For a `ReadStatTable` constructed by [`readstat`](@ref),
 `Cols` is either `ReadStatColumns` or `ChainedReadStatColumns`
 depending on whether multiple threads are used for parsing the data file.
+For a `ReadStatTable` constructed for [`writestat`](@ref),
+`Cols` is allowed to be a column table type for any `Tables.jl`-compatible table.
 See also [`ReadStatMeta`](@ref) and [`ReadStatColMeta`](@ref) for the included metadata.
 """
 struct ReadStatTable{Cols} <: Tables.AbstractColumns
@@ -288,7 +291,7 @@ end
 Base.@propagate_inbounds getcolumnfast(tb::ReadStatTable, i::Int) =
     Tables.getcolumn(_columns(tb), i)
 
-Base.@propagate_inbounds function Tables.getcolumn(tb::ReadStatTable{<:ColumnsOrChained}, i::Int)
+Base.@propagate_inbounds function Tables.getcolumn(tb::ReadStatTable, i::Int)
     lblname = _colmeta(tb, i, :vallabel)
     col = getcolumnfast(tb, i)
     if lblname === Symbol()
@@ -296,12 +299,9 @@ Base.@propagate_inbounds function Tables.getcolumn(tb::ReadStatTable{<:ColumnsOr
     else
         # Value labels might be missing despite their name existing in metadata
         lbls = get(_vallabels(tb), lblname, nothing)
-        return lbls === nothing ? col : LabeledArray(col, lbls)
+        return lbls === nothing ? col : LabeledArray(refarray(col), lbls)
     end
 end
-
-Base.@propagate_inbounds Tables.getcolumn(tb::ReadStatTable, i::Int) =
-    getcolumnfast(tb, i)
 
 Base.@propagate_inbounds Tables.getcolumn(tb::ReadStatTable, n::Symbol) =
     Tables.getcolumn(tb, _lookup(tb)[n])

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -64,10 +64,10 @@ function _write_value(io::IOStream, write_ext, writer, tb::ReadStatTable{<:Colum
 end
 
 function _write_value(io::IOStream, write_ext, writer, tb::ReadStatTable)
-    rows = Tables.rows(_columns(tb))
+    rows = Tables.rows(tb)
     schema = Tables.schema(tb)
     types = _colmeta(tb, :type)
-    write_ext(writer, Ref{IOStream}(io), length(rows))
+    write_ext(writer, Ref{IOStream}(io), nrow(tb))
     for row in rows
         _error(begin_row(writer))
         Tables.eachcolumn(schema, row) do val, i, name

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -134,7 +134,7 @@ function ReadStatTable(table, ext::AbstractString;
             lblname = colmetadata(table, i, "vallabel", Symbol())
             colmeta.vallabel[i] = lblname
             _set_vallabels!(colmeta, vallabels, lblname, refpoolaslabel, names, col, i)
-            # type may have be modified based on refarray
+            # type may have been modified based on refarray
             type = colmeta.type[i]
             if type === READSTAT_TYPE_STRING
                 width = _readstat_string_width(col)
@@ -179,6 +179,7 @@ function ReadStatTable(table::ReadStatTable, ext::AbstractString;
         col = Tables.getcolumn(table, i)
         lblname = colmeta.vallabel[i]
         # PooledArray is not treated as LabeledArray here due to conflict with getindex
+        # Will be fixed after ReadStatColumns is improved for v0.3
         _set_vallabels!(colmeta, vallabels, lblname, false, names, col, i)
         if update_width
             type = colmeta.type[i]

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -36,7 +36,7 @@ end
 
 function _set_vallabels!(colmetavec, vallabels, lblname, refpoolaslabel, names, col, i)
     lbls = get(vallabels, lblname, nothing)
-    lblname == Symbol() && (lblname = Symbol(names[i]))
+    lblname === Symbol() && (lblname = Symbol(names[i]))
     if col isa LabeledArrOrSubOrReshape
         if lbls === nothing
             vallabels[lblname] = getvaluelabels(col)

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -34,7 +34,55 @@ function _readstat_string_width(col)
     end
 end
 
+function _set_vallabels!(colmetavec, vallabels, lblname, refpoolaslabel, names, col, i)
+    lbls = get(vallabels, lblname, nothing)
+    lblname == Symbol() && (lblname = Symbol(names[i]))
+    if col isa LabeledArrOrSubOrReshape
+        if lbls === nothing
+            vallabels[lblname] = getvaluelabels(col)
+        else
+            lbls == getvaluelabels(col) ||
+                error("value label name $lblname is not unique")
+        end
+        colmetavec.vallabel[i] = lblname
+    elseif lblname === Symbol() || lbls === nothing
+        pool = refpool(col)
+        if pool === nothing || !refpoolaslabel
+            # Any specified vallabel is ignored as labels do not exist
+            colmetavec.vallabel[i] = Symbol()
+        else
+            lbls = Dict{Union{Int32,Char},String}(Int32(k) => v for (k, v) in pairs(pool))
+            vallabels[lblname] = lbls
+            colmetavec.type[i] = rstype(nonmissingtype(eltype(refarray(col))))
+            colmetavec.vallabel[i] = lblname
+        end
+    end
+end
+
+"""
+    ReadStatTable(table, ext::AbstractString; kwargs...)
+
+Construct a `ReadStatTable` by wrapping a `Tables.jl`-compatible column table
+for a supported file format with extension `ext`.
+An attempt is made to collect table-level or column-level metadata with a key
+that matches a metadata field in [`ReadStatMeta`](@ref) or [`ReadStatColMeta`](@ref)
+via the `metadata` and `colmetadata` interface defined by `DataAPI.jl`.
+
+This method is used by [`writestat`](@ref) when the provided `table`
+is not already a `ReadStatTable`.
+Hence, it is useful for gaining fine-grained control over the content to be written.
+Metadata may be manually specified with keyword arguments.
+
+# Keywords
+- `refpoolaslabel::Bool = true`: generate value labels for columns of an array type that makes use of `DataAPI.refpool` (e.g., `CategoricalArray` and `PooledArray`).
+- `vallabels::Dict{Symbol, Dict} = Dict{Symbol, Dict}()`: a dictionary of all value label dictionaries indexed by their names.
+- `hasmissing::Vector{Bool} = Vector{Bool}()`: a vector of indicators for whether any missing value present in the corresponding column; irrelavent for writing tables.
+- `meta::ReadStatMeta = ReadStatMeta()`: file-level metadata.
+- `colmeta::ColMetaVec = ReadStatColMetaVec()`: variable-level metadata stored in a `StructArray` of `ReadStatColMeta`s; only used when its length matches the number of columns in `table`.
+- `styles::Dict{Symbol, Symbol} = _default_metastyles()`: metadata styles.
+"""
 function ReadStatTable(table, ext::AbstractString;
+        refpoolaslabel::Bool = true,
         vallabels::Dict{Symbol, Dict} = Dict{Symbol, Dict}(),
         hasmissing::Vector{Bool} = Vector{Bool}(),
         meta::ReadStatMeta = ReadStatMeta(),
@@ -77,9 +125,7 @@ function ReadStatTable(table, ext::AbstractString;
             colmeta.label[i] = colmetadata(table, i, "label", "")
             #! To do: handle format for DateTime columns
             colmeta.format[i] = colmetadata(table, i, "format", "")
-            #! To do: ensure that an array of type such as CategoricalArray works
-            #! Consider constructing value labels for such arrays
-            if col isa LabeledArrOrSubOrReshape
+            if col isa LabeledArrOrSubOrReshape || refpool(col) !== nothing && refpoolaslabel
                 type = rstype(nonmissingtype(eltype(refarray(col))))
             else
                 type = rstype(nonmissingtype(eltype(col)))
@@ -87,16 +133,9 @@ function ReadStatTable(table, ext::AbstractString;
             colmeta.type[i] = colmetadata(table, i, "type", type)
             lblname = colmetadata(table, i, "vallabel", Symbol())
             colmeta.vallabel[i] = lblname
-            if col isa LabeledArrOrSubOrReshape
-                lblname == Symbol() && (lblname = Symbol(names[i]))
-                lbls = get(vallabels, lblname, nothing)
-                if lbls === nothing
-                    vallabels[lblname] = getvaluelabels(col)
-                    colmeta.vallabel[i] = lblname
-                elseif lbls != getvaluelabels(col)
-                    error("value label name $lblname is not unique")
-                end
-            end
+            _set_vallabels!(colmeta, vallabels, lblname, refpoolaslabel, names, col, i)
+            # type may have be modified based on refarray
+            type = colmeta.type[i]
             if type === READSTAT_TYPE_STRING
                 width = _readstat_string_width(col)
             elseif type === READSTAT_TYPE_DOUBLE
@@ -114,12 +153,23 @@ function ReadStatTable(table, ext::AbstractString;
     return ReadStatTable(cols, names, vallabels, hasmissing, meta, colmeta, styles)
 end
 
+"""
+    ReadStatTable(table::ReadStatTable, ext::AbstractString; kwargs...)
+
+Construct a `ReadStatTable` from an existing `ReadStatTable`
+for a supported file format with extension `ext`.
+
+# Keywords
+- `update_width::Bool = true`: determine the storage width for each string variable by checking the actual data columns instead of any existing metadata value.
+"""
 function ReadStatTable(table::ReadStatTable, ext::AbstractString;
         update_width::Bool = true, kwargs...)
     meta = _meta(table)
     meta.row_count = nrow(table)
     meta.var_count = ncol(table)
     colmeta = _colmeta(table)
+    vallabels = _vallabels(table)
+    names = _names(table)
     if ext != meta.file_ext
         meta.file_ext = ext
         meta.file_format_version = get(default_file_format_version, ext, -1)
@@ -127,6 +177,9 @@ function ReadStatTable(table::ReadStatTable, ext::AbstractString;
     end
     for i in 1:ncol(table)
         col = Tables.getcolumn(table, i)
+        lblname = colmeta.vallabel[i]
+        # PooledArray is not treated as LabeledArray here due to conflict with getindex
+        _set_vallabels!(colmeta, vallabels, lblname, false, names, col, i)
         if update_width
             type = colmeta.type[i]
             if type === READSTAT_TYPE_STRING
@@ -161,7 +214,7 @@ after the writer finishes.
 
 # Supported File Formats
 - Stata: `.dta`
-- SAS: `.sas7bdat` and `.xpt` (Note: `SAS` may not recognize the produced `.sas7bdat` files due to a known limitation with `ReadStat`.)
+- SAS: `.sas7bdat` and `.xpt` (Note: SAS may not recognize the produced `.sas7bdat` files due to a known limitation with ReadStat.)
 - SPSS: `.sav` and `por`
 
 # Conversion
@@ -173,13 +226,21 @@ a data column may be written in a different type
 when the closest `ReadStat` type is not supported.
 
 For metadata, if the user-provided `table` is not a [`ReadStatTable`](@ref),
-an attempt will be made to collect
-any table-level or column-level metadata with a key
+an attempt will be made to collect table-level or column-level metadata with a key
 that matches a metadata field in [`ReadStatMeta`](@ref) or [`ReadStatColMeta`](@ref)
 via the `metadata` and `colmetadata` interface defined by `DataAPI.jl`.
 If the `table` is a [`ReadStatTable`](@ref),
 then the associated metadata will be written as long as their values
 are compatible with the format of the output file.
+Value labels associated with a [`LabeledArray`](@ref) are always preserved
+even when the name of the dictionary of value labels is not specified in metadata
+(column name will be used by default).
+If a column is of an array type that makes use of `DataAPI.refpool`
+(e.g., `CategoricalArray` and `PooledArray`),
+value labels will be generated automatically by default
+(with keyword `refpoolaslabel` set to be `true`)
+and the underlying numerical reference values instead of the values returned by `getindex`
+are written to files (with value labels attached).
 """
 function writestat(filepath, table; ext = lowercase(splitext(filepath)[2]), kwargs...)
     filepath = string(filepath)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,8 @@ using Dates
 using InlineStrings
 using PooledArrays
 using ReadStatTables: error_message, READSTAT_COMPRESS_NONE, READSTAT_ENDIAN_NONE,
-    READSTAT_TYPE_INT8, READSTAT_TYPE_INT32, READSTAT_TYPE_DOUBLE, READSTAT_MEASURE_UNKNOWN,
+    READSTAT_TYPE_STRING, READSTAT_TYPE_INT8, READSTAT_TYPE_INT32,
+    READSTAT_TYPE_DOUBLE, READSTAT_MEASURE_UNKNOWN,
     READSTAT_ALIGNMENT_UNKNOWN, READSTAT_ERROR_OPEN, _error,
     Int8Column, _pushmissing!, _pushchain!, _setntasks, rstype
 using SentinelArrays: SentinelArray, SentinelVector, ChainedVector


### PR DESCRIPTION
Value labels are generated for `CategoricalArray` and `PooledArray` by default when writing a table containing such array types.