### PR TITLE
Add `defaultarray` for `LabeledValue` and `apply_value_labels` option

### DIFF
--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -12,7 +12,8 @@ using SentinelArrays: SentinelVector, ChainedVector
 using StructArrays: StructVector
 using Tables
 
-import DataAPI: refarray, unwrap, nrow, ncol, metadatasupport, colmetadatasupport,
+import DataAPI: defaultarray, refarray, unwrap, nrow, ncol,
+    metadatasupport, colmetadatasupport,
     metadata, metadatakeys, metadata!, colmetadata, colmetadatakeys, colmetadata!
 import PrettyTables: compact_type_str
 import Tables: columnnames

--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -40,6 +40,7 @@ $_supported_formats_str
 - `row_offset::Integer = 0`: skip the specified number of rows.
 - `ntasks::Union{Integer, Nothing} = nothing`: number of tasks spawned to read data file in concurrent chunks with multiple threads; with `ntasks` being `nothing` or smaller than 1, select a default value based on the size of data file and the number of threads available (`Threads.nthreads()`); not applicable to `.xpt` and `.por` files where row count is unknown from metadata.
 - `convert_datetime::Bool = true`: convert data from any column with a recognized date/time format to `Date` or `DateTime`.
+- `apply_value_labels::Bool = true`: apply value labels to the associated columns.
 - `inlinestring_width::Integer = ext ∈ (".sav", ".por") ? 0 : 32`: use a fixed-width string type that can be stored inline for any string variable with width below `inlinestring_width` and `pool_width`; a non-positive value avoids using any inline string type; not recommended for SPSS files.
 - `pool_width::Integer = 64`: only attempt to use `PooledArray` for string variables with width of at least 64.
 - `pool_thres::Integer = 500`: do not use `PooledArray` for string variables if the number of unique values exceeds `pool_thres`; a non-positive value avoids using `PooledArray`.
@@ -53,6 +54,7 @@ function readstat(filepath;
         row_offset::Integer = 0,
         ntasks::Union{Integer, Nothing} = nothing,
         convert_datetime::Bool = true,
+        apply_value_labels::Bool = true,
         inlinestring_width::Integer = ext ∈ (".sav", ".por") ? 0 : 32,
         pool_width::Integer = 64,
         pool_thres::Integer = 500,
@@ -155,6 +157,7 @@ function readstat(filepath;
                 @inbounds hms[i] = hmsi
                 _pushchain!(cols, hmsi, map(x->@inbounds(_columns(x)[i]), tbs))
             end
+            apply_value_labels || fill!(cm.vallabel, Symbol())
             return ReadStatTable(cols, names, vlbls, hms, m, cm)
         end
     end
@@ -181,6 +184,7 @@ function readstat(filepath;
             end
         end
     end
+    apply_value_labels || fill!(_colmeta(tb, :vallabel), Symbol())
     return tb
 end
 

--- a/test/LabeledArrays.jl
+++ b/test/LabeledArrays.jl
@@ -59,6 +59,10 @@ end
     @test eltype(x) == LabeledValue{Int, Union{Int,Missing}}
     @test size(x) == (6,)
     @test IndexStyle(typeof(x)) == IndexStyle(typeof(vals))
+    @test DataAPI.defaultarray(eltype(x), 1) == typeof(x)
+    x0 = typeof(x)(undef, 10)
+    @test length(x0) == 10
+    @test isempty(getvaluelabels(x0))
 
     @test x[1] === LabeledValue(1, lbls)
     @test x[Int16(1)] === LabeledValue(1, lbls)
@@ -219,14 +223,27 @@ end
     dest = similar(refarray(x1))
     copyto!(dest, x1)
     @test isequal(dest, refarray(x1))
+    d1 = similar(refarray(dest))
+    copyto!(d1, x1)
+    @test isequal(d1, x1)
     dest = similar(refarray(x1))
     copyto!(IndexLinear(), dest, IndexLinear(), x1)
     @test isequal(dest, refarray(x1))
+    d1 = similar(refarray(dest))
+    copyto!(IndexLinear(), d1, IndexLinear(), x1)
+    @test isequal(d1, x1)
     dest = similar(refarray(x1))
     copyto!(dest, 2, view(x1, 1:3))
     @test isequal(dest[2:4], view(refarray(x1), 1:3))
+    d1 = similar(refarray(dest))
+    copyto!(d1, 2, view(x1, 1:3))
+    @test isequal(d1[2:4], view(refarray(x1), 1:3))
+    dest = similar(refarray(x1))
     copyto!(dest, 2:4, 1:1, x1, 1:3, 1:1)
     @test isequal(dest[2:4], view(refarray(x1), 1:3))
+    d1 = similar(refarray(dest))
+    copyto!(d1, 2:4, 1:1, x1, 1:3, 1:1)
+    @test isequal(d1[2:4], view(refarray(x1), 1:3))
 
     x2 = collect(x)
     @test x2 == x

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -72,6 +72,14 @@ end
         @test colmetadata(df, :mynum, "label", style=true) == ("numeric", :note)
     end
 
+    df = DataFrame(d)
+    df2 = vcat(df, df)
+    @test getvaluelabels(df2.mylabl) == getvaluelabels(df.mylabl)
+    @test getvaluelabels(df2.mylabl) !== getvaluelabels(df.mylabl)
+
+    d = readstat(dta, apply_value_labels=false)
+    @test eltype(d.mylabl) == Union{Missing, Int8}
+
     d = readstat(dta, usecols=Int[])
     @test sprint(show, d) == "0×0 ReadStatTable"
     @test isempty(colmetadata(d))


### PR DESCRIPTION
`readstat` now accepts a Boolean keyword argument `apply_value_labels` to control whether value labels should be applied to columns. At this moment, setting `apply_value_labels` to `false` simply removes the column metadata that indicate the names of value labels. This is the simplest solution for #25, but has the downside of not showing how value labels are originally assigned in the data file.

Missing methods are added in order to allow `vcat` to work when a `DataFrame` contains `LabeledArray`s (#27).