### PR TITLE
Fix `Vararg` deprecation warning

### DIFF
--- a/src/LabeledArrays.jl
+++ b/src/LabeledArrays.jl
@@ -303,7 +303,7 @@ Base.@propagate_inbounds function Base.getindex(x::LabeledArrOrSubOrReshape{V,N}
 end
 
 Base.@propagate_inbounds function Base.getindex(x::LabeledArrOrSubOrReshape{V,N},
-        I::Vararg{<:Integer,N}) where {V,N}
+        I::Vararg{Integer,N}) where {V,N}
     val = refarray(x)[I...]
     return LabeledValue(val, getvaluelabels(x))
 end


### PR DESCRIPTION
On the main branch when precompiling `ReadStatTables` the following deprecation warning is shown (appears e.g. in tests or when you start Julia manually with `--depwarn=yes`):
```julia
┌ ReadStatTables [52522f7a-9570-4e34-8ac6-c005c74d4b84]
│  WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
└
```

The PR fixes this issue.