### PR TITLE
Writing of `DateTime` columns

### DIFF
--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -85,3 +85,11 @@ function parse_datetime(col::AbstractVector, epoch::Union{DateTime,Date}, delta:
     end
     return out
 end
+
+function datetimes_to_doubles(col::AbstractVector{<:Union{Missing,DateTime}}, ext::String, format::String)
+    # TODO: make this more robust than just a double dict lookup
+    epoch, delta = dt_formats[ext][format]
+    map(col) do value
+        value === missing ? missing : (value - epoch) / delta
+    end
+end


### PR DESCRIPTION
cf. https://github.com/junyuan-chen/ReadStatTables.jl/issues/32

This is a draft PR how writing of `DateTime` columns could in principle be achieved. There are still many questions to be answered, however.

The basic idea is to convert `DateTime` columns to double precision numbers. The epoch and delta used are already defined in the package for reading, so they can be reused. However, I've noticed that reading in a dataframe with sub-second precision, I do not recover this data for `.xpt`, e.g., because the reading code rounds to the delta which is `Second`. I don't think this is necessary so maybe this qualifies as a bug in ReadStatTables:

```julia
julia> df = DataFrame(time = now())
1×1 DataFrame
 Row │ time                    
     │ DateTime                
─────┼─────────────────────────
   1 │ 2024-01-04T10:00:15.023

julia> writestat("some_datetime.xpt", df)
1×1 ReadStatTable:
 Row │      time 
     │   Float64 
─────┼───────────
   1 │ 2.01998e9

julia> readstat("some_datetime.xpt")
1×1 ReadStatTable:
 Row │                time 
     │            DateTime 
─────┼─────────────────────
   1 │ 2024-01-04T10:00:15
```

Regarding the appropriate datetime formats, so far I've only taken a brief look at SAS in this context https://documentation.sas.com/doc/en/vdmmlcdc/8.1/leforinforref/n0av4h8lmnktm4n1i33et4wyz5yy.htm. The current code defines the formats below, but the SAS docs say that `DATETIMEw.d` is a dynamic format where `w` can have any width value from 7 to 40 and `d` can be any number of digits after the comma from 0 to 39. So I'm not sure why the below selection is as it is, as all these values seem to specify no decimals after the comma (so no milliseconds). The current reading code also doesn't seem to honor these values at all, it just does the epoch/delta conversion the same way, regardless. I can imagine that if we don't write out values that are correct given the format we specify, we create files that are invalid in SAS.

This is the mentioned list of formats currently found in the code base:

```julia
const sas_datetime_formats = [
    "DATETIME", "DATETIME18", "DATETIME19",  "DATETIME20", "DATETIME21", "DATETIME22", "TOD"
]
```

The way that I'm changing the column representation from `DateTime` to `Float64` is also very hacky currently and just serves as a proof of concept. I'm not sure what the most appropriate path would be given the package's design, maybe the conversion should only happen later in the value writers (which also have comment stubs mentioning datetime support).