### PR TITLE
Support StructArrays 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReadStatTables"
 uuid = "52522f7a-9570-4e34-8ac6-c005c74d4b84"
 authors = ["Junyuan Chen <norman.chen.git@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -31,7 +31,7 @@ PrecompileTools = "1"
 PrettyTables = "1, 2"
 ReadStat_jll = "1.1.9"
 SentinelArrays = "1.2"
-StructArrays = "0.6"
+StructArrays = "0.6, 0.7"
 Tables = "1.2"
 julia = "1.7"
 


### PR DESCRIPTION
This PR prepares for a new release that supports StructArrays 0.7. It seems CompatHelper was disabled automatically due to inactivity, hence no CompatHelper PR was opened.