### PR TITLE
Handle string columns with `Missing` and `Char` for `ReadStatTable`

### DIFF
--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -35,8 +35,7 @@ function _readstat_string_width(col)
         maxlen = maximum(col) do str
             ismissing(str) ? 0 : ncodeunits(str)
         end
-        # In case col only contains Missing
-        return Csize_t(maxlen) # max(maxlen, 1)
+        return Csize_t(maxlen)
     end
 end
 
@@ -80,7 +79,7 @@ is not already a `ReadStatTable`.
 Hence, it is useful for gaining fine-grained control over the content to be written.
 Metadata may be manually specified with keyword arguments.
 
-Any `Missing` existing in string columns will be replaced by an empty string `""`.
+Any `missing` existing in string columns will be replaced by an empty string `""`.
 A column with element type `Missing` is treated as a column with empty strings.
 
 # Keywords
@@ -230,7 +229,7 @@ function ReadStatTable(table, ext::AbstractString;
             elseif eltype(col) != Missing
                 T = nonmissingtype(eltype(col))
                 if T <: AbstractString
-                    # Missing is represented by "" for string columns
+                    # missing is replaced by "" for string columns
                     tarcol .= T.(coalesce.(col, ""))
                 elseif Char <: T
                     tarcol .= string.(coalesce.(col, ""))

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -74,6 +74,37 @@ end
     @test isequal(tb.date.data, [missing, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, -1, -1, -1, -2])
 end
 
+@testset "writestat string" begin
+    outfile = "$(@__DIR__)/../data/test_string.dta"
+    types = [String, String3, String7, String15, String31,
+        String63, String127, String255]
+    cols = [Symbol(:col, i) => T[T("a")] for (i, T) in enumerate(types)]
+    df = DataFrame((; cols...))
+    df[!,:col0] .= 'a'
+    tb = writestat(outfile, df)
+    push!(types, String)
+    for (i, col) in enumerate(tb)
+        @test eltype(col) == types[i]
+        @test col[1] == "a"
+    end
+    allowmissing!(df)
+    df[!,:colm] .= missing
+    for col in eachcol(df)
+        push!(col, missing)
+    end
+    tb = writestat(outfile, df)
+    push!(types, String)
+    for (i, col) in enumerate(tb)
+        @test eltype(col) == types[i]
+        if i < length(tb)
+            @test col[1] == "a"
+            @test col[2] == ""
+        else
+            @test col[1] == ""
+        end
+    end
+end
+
 @testset "writestat dta" begin
     alltypes = "$(@__DIR__)/../data/alltypes.dta"
     dtype = readstat(alltypes)

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -87,6 +87,9 @@ end
         @test eltype(col) == types[i]
         @test col[1] == "a"
     end
+    ws = Int.(colmetavalues(tb, :storage_width))
+    @test ws == [1, 3, 7, 15, 31, 63, 127, 255, 1]
+    readstat(outfile)
     allowmissing!(df)
     df[!,:colm] .= missing
     for col in eachcol(df)
@@ -103,6 +106,9 @@ end
             @test col[1] == ""
         end
     end
+    ws = Int.(colmetavalues(tb, :storage_width))
+    @test ws == [1, 3, 7, 15, 31, 63, 127, 255, 1, 1]
+    readstat(outfile)
 end
 
 @testset "writestat dta" begin


### PR DESCRIPTION
Tables with string columns containing `Missing` and columns of `Char` are processed so that no errors are thrown when trying to directly write such tables.

Columns with element type `Missing` are treated as string columns containing empty strings.

Close #46.