### PR TITLE
Improve `LabeledValue` type printing in `DataFrame`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,9 +18,15 @@ SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
+[weakdeps]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+
+[extensions]
+ReadStatTablesDataFramesExt = "DataFrames"
+
 [compat]
 CEnum = "0.4, 0.5"
-CategoricalArrays = "0.10"
+CategoricalArrays = "0.10, 1"
 DataAPI = "1.13"
 DataFrames = "1"
 InlineStrings = "1.1"
@@ -33,7 +39,7 @@ ReadStat_jll = "1.1.9"
 SentinelArrays = "1.2"
 StructArrays = "0.6, 0.7"
 Tables = "1.2"
-julia = "1.7"
+julia = "1.10"
 
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/ext/ReadStatTablesDataFramesExt.jl
+++ b/ext/ReadStatTablesDataFramesExt.jl
@@ -1,0 +1,10 @@
+module ReadStatTablesDataFramesExt
+
+using DataFrames
+using ReadStatTables
+
+# Follow compact_type_str to get more readable type printing
+DataFrames.compacttype(::Type{<:LabeledValue{V}}, maxwidth::Int) where V =
+    string("Labeled{", DataFrames.compacttype(V, maxwidth), "}")
+
+end # module

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -54,6 +54,8 @@ end
     @test all(n->isequal(df[!, n], getproperty(d, n)), columnnames(d))
     df = DataFrame(d, copycols=false)
     @test all(n->df[!, n] === getproperty(d, n), columnnames(d))
+    # Verify compacttype from ReadStatTablesDataFramesExt is working
+    @test sprint(show, MIME("text/plain"), d)[166:178] == "Labeled{Int8}"
 
     # Metadata-related methods require DataFrames.jl v1.4 or above
     # which requires Julia v1.6 or above


### PR DESCRIPTION
A specialized method of `DataFrames.compacttype` is added via `ReadStatTablesDataFramesExt`.

Julia compat is bumped to 1.10.