### PR TITLE
Write `Bool` as `Int8` and turn off dependabot for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "monthly"
   - package-ecosystem: "julia"
-    directories:
-      - "/"
-      - "/docs"
+    directory: "/"
     schedule:
       interval: "monthly"

--- a/.github/workflows/CI-stable.yml
+++ b/.github/workflows/CI-stable.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'lts'
+          - '1.10'
           - '1'
         os:
           - 'ubuntu-latest'
@@ -26,14 +26,11 @@ jobs:
           - 'x64'
         include:
           - os: 'macos-latest'
-            version: 'lts'
+            version: '1.10'
             arch: 'aarch64'
           - os: 'macos-latest'
             version: '1'
             arch: 'aarch64'
-          - os: 'ubuntu-latest'
-            version: 'min'
-            arch: 'x64'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -7,6 +7,7 @@ const ext2writer = Dict{String, Any}(
 )
 
 # Default mapping from julia types to ReadStat types
+rstype(::Type{Bool}) = READSTAT_TYPE_INT8
 rstype(::Type{Int8}) = READSTAT_TYPE_INT8
 rstype(::Type{Int16}) = READSTAT_TYPE_INT16
 rstype(::Type{<:Integer}) = READSTAT_TYPE_INT32

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -149,6 +149,13 @@ end
     tb4 = writestat("$(@__DIR__)/../data/write_df_alltypes.xpt", dtype)
     tb5 = writestat("$(@__DIR__)/../data/write_df_alltypes.xpt", df)
 
+    df = DataFrame(dtype)
+    df[!,:vbool] = [true, false, missing]
+    tb6 = writestat("$(@__DIR__)/../data/write_df_alltypes.dta", df)
+    @test eltype(tb6.vbool) == Union{Int8,Missing}
+    tb = readstat("$(@__DIR__)/../data/write_df_alltypes.dta")
+    @test all(isequal.(tb.vbool, tb6.vbool))
+
     stringtypes = "$(@__DIR__)/../data/stringtypes.dta"
     strtype = readstat(stringtypes)
     tb = writestat("$(@__DIR__)/../data/write_stringtypes.dta", strtype)


### PR DESCRIPTION
Columns with element type `Bool` are now written as `Int8` columns instead of `Int32` columns.