### PR TITLE
Default `inlinestring_width=0` for `.xpt` and `.sas7bdat`

### DIFF
--- a/src/readstat.jl
+++ b/src/readstat.jl
@@ -40,7 +40,7 @@ $_supported_formats_str
 - `row_offset::Integer = 0`: skip the specified number of rows.
 - `ntasks::Union{Integer, Nothing} = nothing`: number of tasks spawned to read data file in concurrent chunks with multiple threads; with `ntasks` being `nothing` or smaller than 1, select a default value based on the size of data file and the number of threads available (`Threads.nthreads()`); not applicable to `.xpt` and `.por` files where row count is unknown from metadata.
 - `apply_value_labels::Bool = true`: apply value labels to the associated columns.
-- `inlinestring_width::Integer = ext ∈ (".sav", ".por") ? 0 : 32`: use a fixed-width string type that can be stored inline for any string variable with width below `inlinestring_width` and `pool_width`; a non-positive value avoids using any inline string type; not recommended for SPSS files.
+- `inlinestring_width::Integer = ext ∈ (".sav", ".por", ".xpt", ".sas7bdat") ? 0 : 32`: use a fixed-width string type that can be stored inline for any string variable with width below `inlinestring_width` and `pool_width`; a non-positive value avoids using any inline string type; not recommended for SPSS or SAS files.
 - `pool_width::Integer = 64`: only attempt to use `PooledArray` for string variables with width of at least 64.
 - `pool_thres::Integer = 500`: do not use `PooledArray` for string variables if the number of unique values exceeds `pool_thres`; a non-positive value avoids using `PooledArray`.
 - `file_encoding::Union{String, Nothing} = nothing`: manually specify the file character encoding; need to be an `iconv`-compatible name.
@@ -53,7 +53,7 @@ function readstat(filepath;
         row_offset::Integer = 0,
         ntasks::Union{Integer, Nothing} = nothing,
         apply_value_labels::Bool = true,
-        inlinestring_width::Integer = ext ∈ (".sav", ".por") ? 0 : 32,
+        inlinestring_width::Integer = ext ∈ (".sav", ".por", ".xpt", ".sas7bdat") ? 0 : 32,
         pool_width::Integer = 64,
         pool_thres::Integer = 500,
         file_encoding::Union{String, Nothing} = nothing,

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -355,16 +355,21 @@ end
 @testset "readstat sas7bdat" begin
     sas7 = "$(@__DIR__)/../data/sample.sas7bdat"
     d = readstat(sas7)
+    @test eltype(d.mychar) == String
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │  mychar    mynum      mydate                dtime   mylabl    myord               mytime
-             │ String3  Float64       Date?            DateTime?  Float64  Float64            DateTime?
-        ─────┼──────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing      1.0      1.0              missing"""
+         Row │ mychar    mynum      mydate                dtime   mylabl    myord               mytime
+             │ String  Float64       Date?            DateTime?  Float64  Float64            DateTime?
+        ─────┼─────────────────────────────────────────────────────────────────────────────────────────
+           1 │      a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
+           2 │      b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
+           3 │      c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
+           4 │      d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
+           5 │      e   1000.3     missing              missing      1.0      1.0              missing"""
+
+    # Opt-in restores InlineString behavior for SAS files
+    d_inline = readstat(sas7, inlinestring_width=32)
+    @test eltype(d_inline.mychar) == String3
 
     d = readstat(sas7, ntasks=3)
     @test d isa ReadStatTable{ChainedReadStatColumns}
@@ -395,16 +400,21 @@ end
 @testset "readstat xpt" begin
     xpt = "$(@__DIR__)/../data/sample.xpt"
     d = readstat(xpt)
+    @test eltype(d.MYCHAR) == String
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │  MYCHAR    MYNUM      MYDATE                DTIME   MYLABL    MYORD               MYTIME
-             │ String3  Float64       Date?            DateTime?  Float64  Float64            DateTime?
-        ─────┼──────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing      1.0      1.0              missing"""
+         Row │ MYCHAR    MYNUM      MYDATE                DTIME   MYLABL    MYORD               MYTIME
+             │ String  Float64       Date?            DateTime?  Float64  Float64            DateTime?
+        ─────┼─────────────────────────────────────────────────────────────────────────────────────────
+           1 │      a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
+           2 │      b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
+           3 │      c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
+           4 │      d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
+           5 │      e   1000.3     missing              missing      1.0      1.0              missing"""
+
+    # Opt-in restores InlineString behavior for XPT files
+    d_inline = readstat(xpt, inlinestring_width=32)
+    @test eltype(d_inline.MYCHAR) == String3
 
     d = readstat(xpt, ntasks=3)
     @test d isa ReadStatTable{ReadStatColumns}


### PR DESCRIPTION
Extends the existing SPSS-only carve-out so `.xpt` and `.sas7bdat` files also default to `inlinestring_width = 0`. This keeps string column element types consistent across all supported formats out of the box — users who want inline strings for SAS files can still opt in by passing `inlinestring_width=32` (or any positive value).

Closes #70