### PR TITLE
Support writing `Time` columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ wrapping the C interface of ReadStat:
 - Fast multi-threaded data collection from ReadStat parsers to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible `ReadStatTable`
 - Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)
 - Integration of value labels into data columns via a custom array type `LabeledArray`
-- Translation of date and time values into Julia time types `Date` and `DateTime`
+- Translation of date and time values into Julia time types `Date`, `DateTime` and `Time`
 - Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables (experimental)
 
 ## Supported File Formats
@@ -82,14 +82,14 @@ julia> using ReadStatTables
 
 julia> tb = readstat("data/sample.dta")
 5×7 ReadStatTable:
- Row │  mychar    mynum      mydate                dtime         mylabl           myord               mytime 
-     │ String3  Float64       Date?            DateTime?  Labeled{Int8}  Labeled{Int8?}             DateTime 
-─────┼───────────────────────────────────────────────────────────────────────────────────────────────────────
-   1 │       a      1.1  2018-05-06  2018-05-06T10:10:10           Male             low  1960-01-01T10:10:10
-   2 │       b      1.2  1880-05-06  1880-05-06T10:10:10         Female          medium  1960-01-01T23:10:10
-   3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00           Male            high  1960-01-01T00:00:00
-   4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00         Female             low  1960-01-01T16:10:10
-   5 │       e   1000.3     missing              missing           Male         missing  2000-01-01T00:00:00
+ Row │  mychar    mynum      mydate                dtime         mylabl           myord    mytime
+     │ String3  Float64       Date?            DateTime?  Labeled{Int8}  Labeled{Int8?}      Time
+─────┼────────────────────────────────────────────────────────────────────────────────────────────
+   1 │       a      1.1  2018-05-06  2018-05-06T10:10:10           Male             low  10:10:10
+   2 │       b      1.2  1880-05-06  1880-05-06T10:10:10         Female          medium  23:10:10
+   3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00           Male            high  00:00:00
+   4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00         Female             low  16:10:10
+   5 │       e   1000.3     missing              missing           Male         missing  00:00:00
 ```
 
 To access a column from the above table:
@@ -107,7 +107,7 @@ julia> tb.myord
 Notice that for data variables with value labels,
 both the original values and the value labels are preserved.
 For variables representing date/time,
-the translation to Julia `Date`/`DateTime` is lazy.
+the translation to Julia `Date`/`DateTime`/`Time` is lazy.
 One can access the underlying numerical values as follows:
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,7 +33,7 @@ wrapping the C interface of ReadStat:
 - Fast multi-threaded data collection from ReadStat parsers to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible `ReadStatTable`
 - Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)
 - Integration of value labels into data columns via a custom array type `LabeledArray`
-- Translation of date and time values into Julia time types `Date` and `DateTime`
+- Translation of date and time values into Julia time types `Date`, `DateTime` and `Time`
 - Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables (experimental)
 
 ## Supported File Formats

--- a/docs/src/man/date-and-time-values.md
+++ b/docs/src/man/date-and-time-values.md
@@ -23,13 +23,16 @@ is sufficient for uncovering the represented date/time values for a given format
     Conversion for a variable with format `"%tw"` is therefore handled differently.
     For `"%ty"`, the recorded numerical values are simply the calendar years
     without any transformation.
-    A variable with format `"%ty"` is not converted to Julia `Date` or `DateTime`.
+    A variable with format `"%ty"` is not converted to Julia `Date`, `DateTime` or `Time`.
 
 If a variable is in a date/time format that can be recognized,
-the values will be displayed as Julia `Date` or `DateTime`
+the values will be displayed as Julia `Date`, `DateTime` or `Time`
 when printing a `ReadStatTable`.
+Time-of-day formats (SAS/SPSS `TIME*` and Stata `%tcHH:MM:SS`/`%tcHH:MM`)
+are translated to `Time`, while date-only formats translate to `Date`
+and date-with-time formats translate to `DateTime`.
 Notice that the underlying numerical values are preserved
-and the conversion to the Julia `Date` or `DateTime` happens only lazily
+and the conversion to the Julia `Date`, `DateTime` or `Time` happens only lazily
 via a [`MappedArray`](https://github.com/JuliaArrays/MappedArrays.jl)
 when working with a `ReadStatTable`.
 
@@ -39,6 +42,8 @@ tb = readstat("data/sample.dta")
 tb.mydate
 tb.mydate.data
 colmetadata(tb, :mydate, "format")
+tb.mytime
+colmetadata(tb, :mytime, "format")
 ```
 
 The variable-level metadata key named `format` informs

--- a/docs/src/man/getting-started.md
+++ b/docs/src/man/getting-started.md
@@ -24,7 +24,7 @@ Some additional details to be noted:
 
 - If a variable contains any missing value, there is a question mark `?` in the displayed element type.
 - By default, all missing values are treated as [`missing`](https://docs.julialang.org/en/v1/manual/missing/), a special value in Julia.
-- The date and time values have been translated into `Date` and `DateTime` respectively.[^2]
+- The date and time values have been translated into `Date`, `DateTime` and `Time` respectively.[^2]
 - Labels instead of the numeric values are displayed for variables with value labels.
 - `Labeled{Int8}` is an abbreviation for [`LabeledValue{Int8}`](@ref).
 
@@ -231,4 +231,4 @@ ReadStatTable(table::ReadStatTable, ext::AbstractString; kwargs...)
 
 [^1]: The printed output is generated with [PrettyTables.jl](https://github.com/ronisbr/PrettyTables.jl).
 
-[^2]: The time types `Date` and `DateTime` are from the [Dates](https://docs.julialang.org/en/v1/stdlib/Dates/) module of Julia.
+[^2]: The time types `Date`, `DateTime` and `Time` are from the [Dates](https://docs.julialang.org/en/v1/stdlib/Dates/) module of Julia. Time-of-day variables (e.g., Stata `%tcHH:MM:SS`/`%tcHH:MM` and SAS/SPSS `TIME*` formats) are translated into `Time` rather than `DateTime`.

--- a/docs/src/man/table-interface.md
+++ b/docs/src/man/table-interface.md
@@ -76,4 +76,4 @@ tb[1,:dtime]
 Notice that for data columns with value labels,
 these methods only deal with the underlying values and disregard the value labels.
 Similarly, for data columns with a date/time format,
-the numerical values instead of the converted `Date`/`DateTime` values are returned.
+the numerical values instead of the converted `Date`/`DateTime`/`Time` values are returned.

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -21,7 +21,7 @@ import Tables: columnnames
 
 export refarray, unwrap, nrow, ncol, metadata, metadatakeys, metadata!,
     colmetadata, colmetadatakeys, colmetadata!
-export Date, DateTime # Needed for avoiding the "Dates." qualifier when printing tables
+export Date, DateTime, Time # Needed for avoiding the "Dates." qualifier when printing tables
 export String3, String7, String15, String31, String63, String127, String255
 export disallowmissing
 export columnnames

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -4,6 +4,12 @@ const sas_epoch_time = DateTime(1960, 1, 1)
 const sas_epoch_date = Date(1960, 1, 1)
 const spss_epoch_time = DateTime(1582, 10, 14)
 
+# Time-of-day conventions follow pyreadstat:
+# https://github.com/Roche/pyreadstat/blob/e23b1d8e56b155586cc562827972b6f7e30aab00/pyreadstat/_readstat_writer.pyx#L144-L216
+const time_of_day_epoch = Time(0)
+const stata_time_of_day_delta = Millisecond(1)
+const sas_spss_time_of_day_delta = Second(1)
+
 # Reference: Stata documentation
 # No need to handle %ty because values are already calendar years
 const stata_dt_formats = Dict{String, Tuple{Union{DateTime,Date}, Period}}(
@@ -50,7 +56,7 @@ const spss_date_formats = [
     "DATE", "DATE8", "DATE11", "DATE12", "ADATE", "ADATE8", "ADATE10",
     "EDATE", "EDATE8", "EDATE10", "JDATE", "JDATE5", "JDATE7", "SDATE", "SDATE8", "SDATE10"
 ]
-const spss_time_formats = ["TIME", "DTIME", "TIME8", "TIME5", "TIME11.2"]
+const spss_time_formats = ["TIME", "DTIME", "TIME8", "TIME5", "TIME9", "TIME11.2"]
 
 const spss_dt_formats = Dict{String, Tuple{Union{DateTime,Date}, Period}}(
     vcat(spss_datetime_formats, spss_date_formats, spss_time_formats) .=>
@@ -113,7 +119,56 @@ const ext_default_time_format = Dict{String, String}(
     ".xpt" => "DATETIME"
 )
 
-struct Num2DateTime{DT<:Union{DateTime, Date}, P<:Period}
+const ext_time_of_day_epoch = Dict{String, Time}(
+    ".dta" => time_of_day_epoch,
+    ".sav" => time_of_day_epoch,
+    ".por" => time_of_day_epoch,
+    ".sas7bdat" => time_of_day_epoch,
+    ".xpt" => time_of_day_epoch
+)
+
+const ext_default_time_of_day_delta = Dict{String, Period}(
+    ".dta" => stata_time_of_day_delta,
+    ".sav" => sas_spss_time_of_day_delta,
+    ".por" => sas_spss_time_of_day_delta,
+    ".sas7bdat" => sas_spss_time_of_day_delta,
+    ".xpt" => sas_spss_time_of_day_delta
+)
+
+const ext_default_time_of_day_format = Dict{String, String}(
+    ".dta" => "%tcHH:MM:SS",
+    ".sav" => "TIME",
+    ".por" => "TIME",
+    ".sas7bdat" => "TIME",
+    ".xpt" => "TIME"
+)
+
+# Stata time-of-day formats per pyreadstat
+const stata_time_of_day_formats = ["%tcHH:MM:SS", "%tcHH:MM"]
+
+# Read-side lookup: format -> (Time(0), delta). Checked before dt_formats so
+# time-only columns deserialize to Dates.Time rather than DateTime.
+const stata_tod_dt_formats = Dict{String, Tuple{Time, Period}}(
+    f => (time_of_day_epoch, stata_time_of_day_delta) for f in stata_time_of_day_formats
+)
+
+const sas_tod_dt_formats = Dict{String, Tuple{Time, Period}}(
+    f => (time_of_day_epoch, sas_spss_time_of_day_delta) for f in sas_time_formats
+)
+
+const spss_tod_dt_formats = Dict{String, Tuple{Time, Period}}(
+    f => (time_of_day_epoch, sas_spss_time_of_day_delta) for f in spss_time_formats
+)
+
+const ext_time_of_day_dt_formats = Dict{String, Dict{String, Tuple{Time, Period}}}(
+    ".dta" => stata_tod_dt_formats,
+    ".sav" => spss_tod_dt_formats,
+    ".por" => spss_tod_dt_formats,
+    ".sas7bdat" => sas_tod_dt_formats,
+    ".xpt" => sas_tod_dt_formats
+)
+
+struct Num2DateTime{DT<:Union{DateTime, Date, Time}, P<:Period}
     epoch::DT
     delta::P
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -301,6 +301,10 @@ Base.@propagate_inbounds function Tables.getcolumn(tb::ReadStatTable, i::Int)
     # Construct MappedArray if format is a recognized date/time format
     format = _colmeta(tb, i, :format)
     ext = _meta(tb).file_ext
+    # Time-of-day match uses the full format string so Stata "%tcHH:MM:SS" hits
+    # before the family truncation collapses it to "%tc"
+    tod = get(get(ext_time_of_day_dt_formats, ext, nothing), format, nothing)
+    tod === nothing || return num2datetime(col, Num2DateTime(tod...))
     ext == ".dta" && (format = first(format, 3))
     dtpara = get(dt_formats[ext], format, nothing)
     return dtpara === nothing ? col : num2datetime(col, Num2DateTime(dtpara...))

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -147,25 +147,38 @@ function ReadStatTable(table, ext::AbstractString;
                 colmeta.format[i] = format = mformat
             end
         end
-        # Lazily convert any Date/DateTime column
-        if nonmissingtype(eltype(col)) ∈ (Date, DateTime) # Avoid Missing column
+        # Lazily convert any Date/DateTime/Time column
+        if nonmissingtype(eltype(col)) ∈ (Date, DateTime, Time) # Avoid Missing column
             copycols || error("to write tables with date/time columns, copycols must be true")
-            ext == ".dta" && (format = first(format, 3))
-            dtpara = get(dt_formats[ext], format, nothing)
-            if dtpara === nothing
-                if Date <: eltype(col)
-                    epoch = ext_date_epoch[ext]
-                    delta = ext_default_date_delta[ext]
-                    colmeta.format[i] = ext_default_date_format[ext]
-                else
-                    epoch = ext_time_epoch[ext]
-                    delta = ext_default_time_delta[ext]
-                    colmeta.format[i] = ext_default_time_format[ext]
-                end
+            # Time-of-day match uses the full format string so Stata "%tcHH:MM:SS"
+            # routes to a Time epoch before the family truncation hits
+            todpara = get(get(ext_time_of_day_dt_formats, ext, nothing), format, nothing)
+            if todpara !== nothing
+                epoch, delta = todpara
+                Time <: eltype(col) ||
+                    error("a Time column is required for a time-of-day format")
             else
-                epoch, delta = dtpara
-                nonmissingtype(eltype(col)) == typeof(epoch) ||
-                    error("a date/datetime column must have a date/datetime format")
+                ext == ".dta" && (format = first(format, 3))
+                dtpara = get(dt_formats[ext], format, nothing)
+                if dtpara === nothing
+                    if Date <: eltype(col)
+                        epoch = ext_date_epoch[ext]
+                        delta = ext_default_date_delta[ext]
+                        colmeta.format[i] = ext_default_date_format[ext]
+                    elseif DateTime <: eltype(col)
+                        epoch = ext_time_epoch[ext]
+                        delta = ext_default_time_delta[ext]
+                        colmeta.format[i] = ext_default_time_format[ext]
+                    else
+                        epoch = ext_time_of_day_epoch[ext]
+                        delta = ext_default_time_of_day_delta[ext]
+                        colmeta.format[i] = ext_default_time_of_day_format[ext]
+                    end
+                else
+                    epoch, delta = dtpara
+                    nonmissingtype(eltype(col)) == typeof(epoch) ||
+                        error("a date/datetime column must have a date/datetime format")
+                end
             end
             col = datetime2num(col, Num2DateTime(epoch, delta))
         end

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -11,14 +11,14 @@ end
     @test d isa ReadStatTable{ReadStatColumns}
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,120)) == """
         5×7 ReadStatTable:
-         Row │  mychar    mynum      mydate                dtime         mylabl           myord               mytime
-             │ String3  Float64       Date?            DateTime?  Labeled{Int8}  Labeled{Int8?}             DateTime
-        ─────┼───────────────────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10           Male             low  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10         Female          medium  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00           Male            high  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00         Female             low  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing           Male         missing  2000-01-01T00:00:00"""
+         Row │  mychar    mynum      mydate                dtime         mylabl           myord    mytime
+             │ String3  Float64       Date?            DateTime?  Labeled{Int8}  Labeled{Int8?}      Time
+        ─────┼────────────────────────────────────────────────────────────────────────────────────────────
+           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10           Male             low  10:10:10
+           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10         Female          medium  23:10:10
+           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00           Male            high  00:00:00
+           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00         Female             low  16:10:10
+           5 │       e   1000.3     missing              missing           Male         missing  00:00:00"""
     m = metadata(d)
     @test getvaluelabels(d, :mylabl) == d.mylabl.labels
     @test minute(m.modified_time) == 36
@@ -273,14 +273,14 @@ end
     d = readstat(sav)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │ mychar    mynum               mydate                dtime            mylabl             myord               mytime
-             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}            DateTime?
-        ─────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low  1582-10-14T10:10:10
-           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium  1582-10-14T23:10:10
-           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high  1582-10-14T00:00:00
-           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low  1582-10-14T16:10:10
-           5 │      e   1000.3              missing              missing              Male               low              missing"""
+         Row │ mychar    mynum               mydate                dtime            mylabl             myord    mytime
+             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}     Time?
+        ─────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────
+           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low  10:10:10
+           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium  23:10:10
+           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high  00:00:00
+           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low  16:10:10
+           5 │      e   1000.3              missing              missing              Male               low   missing"""
 
     d = readstat(sav, ntasks=3)
     @test d isa ReadStatTable{ChainedReadStatColumns}
@@ -315,14 +315,14 @@ end
     d = readstat(por)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │ MYCHAR    MYNUM               MYDATE                DTIME            MYLABL             MYORD               MYTIME
-             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}            DateTime?
-        ─────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low  1582-10-14T10:10:10
-           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium  1582-10-14T23:10:10
-           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high  1582-10-14T00:00:00
-           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low  1582-10-14T16:10:10
-           5 │      e   1000.3              missing              missing              Male               low              missing"""
+         Row │ MYCHAR    MYNUM               MYDATE                DTIME            MYLABL             MYORD    MYTIME
+             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}     Time?
+        ─────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────
+           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low  10:10:10
+           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium  23:10:10
+           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high  00:00:00
+           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low  16:10:10
+           5 │      e   1000.3              missing              missing              Male               low   missing"""
 
     d = readstat(por, ntasks=3)
     @test d isa ReadStatTable{ReadStatColumns}
@@ -357,14 +357,14 @@ end
     d = readstat(sas7)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │  mychar    mynum      mydate                dtime   mylabl    myord               mytime
-             │ String3  Float64       Date?            DateTime?  Float64  Float64            DateTime?
-        ─────┼──────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing      1.0      1.0              missing"""
+         Row │  mychar    mynum      mydate                dtime   mylabl    myord    mytime
+             │ String3  Float64       Date?            DateTime?  Float64  Float64     Time?
+        ─────┼───────────────────────────────────────────────────────────────────────────────
+           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  10:10:10
+           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  23:10:10
+           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  00:00:00
+           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  16:10:10
+           5 │       e   1000.3     missing              missing      1.0      1.0   missing"""
 
     d = readstat(sas7, ntasks=3)
     @test d isa ReadStatTable{ChainedReadStatColumns}
@@ -397,14 +397,14 @@ end
     d = readstat(xpt)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │  MYCHAR    MYNUM      MYDATE                DTIME   MYLABL    MYORD               MYTIME
-             │ String3  Float64       Date?            DateTime?  Float64  Float64            DateTime?
-        ─────┼──────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing      1.0      1.0              missing"""
+         Row │  MYCHAR    MYNUM      MYDATE                DTIME   MYLABL    MYORD    MYTIME
+             │ String3  Float64       Date?            DateTime?  Float64  Float64     Time?
+        ─────┼───────────────────────────────────────────────────────────────────────────────
+           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  10:10:10
+           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  23:10:10
+           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  00:00:00
+           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  16:10:10
+           5 │       e   1000.3     missing              missing      1.0      1.0   missing"""
 
     d = readstat(xpt, ntasks=3)
     @test d isa ReadStatTable{ReadStatColumns}

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -230,4 +230,11 @@ extensions = ["dta", "por", "sav", "sas7bdat", "xpt"]
     r = readstat(datetimefile)
     @test r.DATE == datetime.DATE
     @test r.TIME == datetime.TIME
+
+    # Issue #68: Time-of-day columns
+    tod = DataFrame((ATM = [Time(8, 30), Time(12), Time(23, 59, 59), missing],))
+    todfile = "$(@__DIR__)/../data/test_write_time.$ext"
+    tb = writestat(todfile, tod)
+    r = readstat(todfile)
+    @test isequal(r.ATM, tod.ATM)
 end


### PR DESCRIPTION
## Summary

`writestat` errored on `Dates.Time` columns because `rstype` only handled `Date` and `DateTime`.

- **Write** path: time-of-day conventions follow [pyreadstat](https://github.com/Roche/pyreadstat/blob/e23b1d8e56b155586cc562827972b6f7e30aab00/pyreadstat/_readstat_writer.pyx#L144-L216) — seconds-since-midnight + `"TIME"` for SAS/SPSS, milliseconds-since-midnight + `"%tcHH:MM:SS"` for Stata.
- **Read** path: SAS/SPSS `TIME*` and Stata `%tcHH:MM:SS` / `%tcHH:MM` columns now deserialize to `Dates.Time` instead of `DateTime`. The Stata format-family truncation in `Tables.getcolumn` is reordered so `%tcHH:MM:SS` matches the Time entry before collapsing to `%tc`.
- `Num2DateTime{DT}` widened to include `Time`; existing `<:Union{Millisecond, Second}` methods generalize.
- Added `TIME9` to `spss_time_formats` to match the format string SPSS auto-emits with display_width=9.
- `Dates.Time` exported alongside `Date`/`DateTime` so the qualifier is stripped when rendering tables.

## Behavior change

Reading a SAS / SPSS file with a `TIME`-formatted column previously yielded `Dates.DateTime` (anchored at the file's epoch); it now yields `Dates.Time`. Same for Stata `%tcHH:MM:SS` / `%tcHH:MM`. This matches what pyreadstat returns and makes Time write/read roundtrips lossless.

Closes #68