### PR TITLE
Add `HMS` and support pure time/duration variables

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using ReadStatTables
 using CategoricalArrays
 using PooledArrays
 
-DocMeta.setdocmeta!(ReadStatTables, :DocTestSetup, :(using ReadStatTables, CategoricalArrays))
+DocMeta.setdocmeta!(ReadStatTables, :DocTestSetup, :(using ReadStatTables, CategoricalArrays, Dates))
 
 makedocs(
     modules = [ReadStatTables],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,8 +33,8 @@ wrapping the C interface of ReadStat:
 - Fast multi-threaded data collection from ReadStat parsers to a [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible `ReadStatTable`
 - Interface of file-level and variable-level metadata compatible with [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)
 - Integration of value labels into data columns via a custom array type `LabeledArray`
-- Translation of date and time values into Julia time types `Date` and `DateTime`
-- Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables (experimental)
+- Translation of date and time values into Julia types `Date` and `DateTime` or a custom `HMS` type
+- Write support for [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible tables
 
 ## Supported File Formats
 
@@ -61,7 +61,7 @@ The main limitations to be addressed are the following:
 
 - Read support for SAS value labels is temporarily absent.
 - All missing values are represented by a single value `missing`.[^2]
-- Write support for the file formats is experimental and not fully developed.
+- Write support for the file formats is mostly complete but should be used with caution.
 
 [^1]:
 

--- a/docs/src/man/date-and-time-values.md
+++ b/docs/src/man/date-and-time-values.md
@@ -6,13 +6,43 @@ Many data/time formats can be recognized without user intervention.[^1]
 In case certain date/time formats are not recognized,
 they can be added easily.
 
-## Translating Date and Time Values
+## The Three Categories
 
-For all date/time formats from Stata, SAS and SPSS,
-the date and time values are stored as the numbers of periods elapsed
-since a reference date or time point (epoch) chosen by the software.
-Therefore, knowing the reference data/time and the length of a single period
-is sufficient for uncovering the represented date/time values for a given format.
+The variable formats defined by the statistical software
+are classified into three categories that affect
+how they are stored in memory and translated to Julia types:
+datetime, date and time.
+Within a category, there can be multiple formats
+but they only alter how data are displayed on screen (in the corresponding software)
+without affecting how they are stored in memory.
+
+| Category | Explanation |
+| :--- | :--- |
+| datetime | Record both the date and the time within a day in a single value |
+| date | Record only the date in a value |
+| time | Record either time within a day or length of period without calendar date |
+
+The statistical software represents variables of these formats
+as numeric values internally based on certain rules.
+Stata provides formats dedicated to datetime (`%tc`) and date (e.g., `%td`) but not time.
+For a pure time variable without meaningful date,
+`%tc` may be used if time strictly refers to a time point within a date.
+SAS and SPSS have built-in formats of all three categories.
+For SAS, variables of the three categories are recorded as numeric values
+in three different ways.
+SPSS uses the same approach to represent both datetime and date
+but only alters how they are displayed.
+For (pure) time variables,
+SAS and SPSS record them as the number of seconds elapsed
+(without a specific starting point on calendar).
+
+## Translating Datetime and Date
+
+All datetime or date formats from Stata, SAS and SPSS
+are stored as the numbers of periods elapsed
+since a reference datetime or date (epoch) chosen by the software.
+Therefore, knowing the epoch and the length of a single period
+is sufficient for uncovering the represented datetime or date for a given format.
 
 !!! info
 
@@ -21,14 +51,14 @@ is sufficient for uncovering the represented date/time values for a given format
     Each year always consists of 52 weeks.
     Any remaining day at the end of a year is counted as the 52th week within that year.
     Conversion for a variable with format `"%tw"` is therefore handled differently.
-    For `"%ty"`, the recorded numerical values are simply the calendar years
+    For `"%ty"`, the recorded numeric values are simply the calendar years
     without any transformation.
     A variable with format `"%ty"` is not converted to Julia `Date` or `DateTime`.
 
-If a variable is in a date/time format that can be recognized,
-the values will be displayed as Julia `Date` or `DateTime`
+If a variable is in a recognized format,
+the values will be displayed as Julia `Datetime` or `Date`
 when printing a `ReadStatTable`.
-Notice that the underlying numerical values are preserved
+Notice that the underlying numeric values are preserved
 and the conversion to the Julia `Date` or `DateTime` happens only lazily
 via a [`MappedArray`](https://github.com/JuliaArrays/MappedArrays.jl)
 when working with a `ReadStatTable`.
@@ -42,10 +72,9 @@ colmetadata(tb, :mydate, "format")
 ```
 
 The variable-level metadata key named `format` informs
-`ReadStatTable` whether the variable represents date/time
-and how the numerical values should be interpreted.
-Changing the `format` directly affects how the values are displayed,
-although the numerical values remain unchanged.
+`ReadStatTable` how the numeric values should be interpreted.
+Changing the `format` may affect how the values are displayed,
+although the numeric values remain unchanged.
 
 ```@repl date
 colmetadata!(tb, :mydate, "format", "%tm")
@@ -54,9 +83,10 @@ colmetadata!(tb, :mydate, "format", "%8.0f")
 tb.mydate
 ```
 
-Copying a `ReadStatTable` (e.g., converting to a `DataFrame`)
-may drop the underlying numerical values.
-Hence, users who wish to directly work with the underlying numerical values
+For datetime and date variables,
+copying a `ReadStatTable` (e.g., converting to a `DataFrame`)
+may drop the underlying numeric values.
+Hence, users who wish to directly work with the underlying numeric values
 may want to preserve the `ReadStatTable` generated from the data file.
 
 ```@repl date
@@ -65,12 +95,14 @@ df.mydate
 ```
 
 In the above example, `df.mydate` only contains the `Date` values
-and the underlying numerical values are lost when constructing the `DataFrame`.
+and the underlying numeric values are lost when constructing the `DataFrame`.
+However, when writing columns with `DateTime` or `Date` back to files,
+[`writestat`](@ref) will convert them to numeric values based on the file extension.
 
-The full lists of recognized date/time formats for the statistical software
+The full lists of recognized datetime or date formats for the statistical software
 are stored as dictionary keys;
-while the associated values are tuples of reference date/time and period length.[^2]
-If a date/time format is not found in the dictionary,
+while the associated values are tuples of reference datetime/date and period length.[^2]
+If a datetime/date format is not found in the dictionary,
 no type conversion will be attempted.
 Additional formats may be added by inserting key-value pairs to the relevant dictionaries.
 
@@ -80,8 +112,39 @@ using ReadStatTables
 
 ```@repl time
 ReadStatTables.stata_dt_formats
-ReadStatTables.sas_dt_formats["MMDDYY"]
-ReadStatTables.spss_dt_formats["TIME"]
+ReadStatTables.sas_dt_formats["DATETIME"]
+ReadStatTables.spss_dt_formats["DATE"]
+```
+
+## Translating Time
+
+Time variables in SAS and SPSS do not necessarily represent a time point in a day.
+They are simply recorded as number of seconds elapsed,
+which are allowed to go above 24 hours.
+For this reason, it is not always possible to convert time variables to Julia `Time`,
+which strictly refers to time in a day ranging from `00:00:00` to `23:59:59.999999999`.
+Depending on the use case,
+time variables in SAS and SPSS may either be time in a day just like Julia `Time`
+or time duration that is more like a Julia `TimePeriod`.
+
+Without imposing a specific interpretation for time variables,
+when retrieving a variable with a time format,
+`ReadStatTable` wraps the column as `HMSCol`.
+This custom vector type lazily converts the number of seconds to
+a more readable `H:MM:SS.dd` format when needed
+to ease a quick browsing of the data.
+It is up to the users to decide how the time variables should be processed in Julia.
+The underlying numeric values representing the number of seconds
+are preserved and can be retrieved by calling [`refarray`](@ref).
+When writing a table back to SAS/SPSS files,
+columns with element type being `Time` or `HMS` are saved as number of seconds.
+For Stata, users are expected to take an explicit stand
+on how such variables should be stored
+by converting the data to either `DateTime` or numeric values.
+
+```@docs
+HMS
+HMSCol
 ```
 
 [^1]:

--- a/docs/src/man/getting-started.md
+++ b/docs/src/man/getting-started.md
@@ -190,8 +190,10 @@ for the printed value of `Date` in the above example.
 
 !!! warning
 
-    The write support is experimental and requires further testing.
-    Caution should be taken when writing the data files.
+    Caution should be taken when writing non-recoverable data to files.
+
+For SAS and SPSS, variables containing `Time` or `HMS` are handled automatically.
+See [Date and Time Values](@ref) for more details.
 
 ## More Options
 

--- a/src/ReadStatTables.jl
+++ b/src/ReadStatTables.jl
@@ -16,6 +16,7 @@ using Tables
 import DataAPI: defaultarray, refarray, unwrap, nrow, ncol,
     metadatasupport, colmetadatasupport,
     metadata, metadatakeys, metadata!, colmetadata, colmetadatakeys, colmetadata!
+import Dates: Time
 import Missings: disallowmissing
 import Tables: columnnames
 
@@ -34,6 +35,9 @@ export LabeledValue,
        getvaluelabels,
        convertvalue,
        valuelabels,
+
+       HMS,
+       HMSCol,
 
        ReadStatColumns,
        ChainedReadStatColumns,

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -343,6 +343,18 @@ function Base.alignment(io::IO, t::HMS)
     return textwidth(first(s, i-1)), textwidth(SubString(s, i))
 end
 
+"""
+    HMSCol{T, A<:AbstractVector{T}} <: AbstractVector{HMS{T}}
+
+A column (vector) that lazily maps number of seconds to [`HMS`](@ref) for readability.
+
+`HMSCol` simply wraps a data column containing the numeric values
+so that any element retrieved is converted to [`HMS`](@ref) on the fly.
+The array of values underlying an `HMSCol`
+can be accessed via [`refarray`](@ref).
+Users are expected to convert the data column appropriately for further processing,
+as `HMSCol` is not intended for usage beyond a quick view of data on REPL.
+"""
 struct HMSCol{T, A<:AbstractVector{T}} <: AbstractVector{HMS{T}}
     a::A
     function HMSCol(a::AbstractVector{T}) where T
@@ -355,18 +367,12 @@ end
 """
     refarray(x::HMSCol)
     refarray(x::SubArray{<:Any, <:Any, <:HMSCol})
-    refarray(x::Base.ReshapedArray{<:Any, <:Any, <:HMSCol})
-    refarray(x::SubArray{<:Any, <:Any, <:Base.ReshapedArray{<:Any, <:Any, <:HMSCol}})
 
 Return the array of values underlying a [`HMSCol`](@ref).
 """
 refarray(x::HMSCol) = x.a
 refarray(x::SubArray{<:Any, <:Any, <:HMSCol}) =
     view(parent(x).a, x.indices...)
-refarray(x::Base.ReshapedArray{<:Any, <:Any, <:HMSCol}) =
-    reshape(parent(x).a, size(x))
-refarray(x::SubArray{<:Any, <:Any, <:Base.ReshapedArray{<:Any, <:Any, <:HMSCol}}) =
-    view(reshape(parent(parent(x)).a, size(parent(x))), x.indices...)
 
 Base.size(col::HMSCol) = size(refarray(col))
 Base.IndexStyle(::Type{<:HMSCol{T,A}}) where {T,A} = IndexStyle(A)

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -1,13 +1,19 @@
-const stata_epoch_time = DateTime(1960, 1, 1)
+# Stata does not have a pure time type (without counting date internally)
+# SPSS does not have a pure date type (without counting time internally)
+# SAS has all three
+# Pure time types always start from 0 and do not need epoch
+const stata_epoch_datetime = DateTime(1960, 1, 1)
 const stata_epoch_date = Date(1960, 1, 1)
-const sas_epoch_time = DateTime(1960, 1, 1)
+const sas_epoch_datetime = DateTime(1960, 1, 1)
 const sas_epoch_date = Date(1960, 1, 1)
-const spss_epoch_time = DateTime(1582, 10, 14)
+const spss_epoch_datetime = DateTime(1582, 10, 14)
 
 # Reference: Stata documentation
 # No need to handle %ty because values are already calendar years
+# Only consider what matters for storage
+# Any extra code for "details" that controls displaying is ignored
 const stata_dt_formats = Dict{String, Tuple{Union{DateTime,Date}, Period}}(
-    "%tc" => (stata_epoch_time, Millisecond(1)),
+    "%tc" => (stata_epoch_datetime, Millisecond(1)),
     "%td" => (stata_epoch_date, Day(1)),
     # %tw will be handled differently
     "%tw" => (stata_epoch_date, Week(1)),
@@ -17,6 +23,13 @@ const stata_dt_formats = Dict{String, Tuple{Union{DateTime,Date}, Period}}(
 )
 
 # Reference: https://github.com/Roche/pyreadstat/blob/master/pyreadstat/_readstat_parser.pyx
+# Changes are made for correction
+# TOD is a display format not tied to datetime and can be time
+const sas_datetime_formats = [
+    "DATETIME", "DATETIME13", "DATETIME18", "DATETIME19",  "DATETIME20", "DATETIME21",
+    "DATETIME22", "E8601DT", "E8601DX", "E8601DZ", "E8601LX", "E8601DN",
+    "E8601LZ", "E8601TX", "E8601TZ"
+]
 const sas_date_formats = [
     "WEEKDATE", "MMDDYY", "DDMMYY", "YYMMDD", "DATE", "DATE9", "YYMMDD10",
     "DDMMYYB", "DDMMYYB10", "DDMMYYC", "DDMMYYC10", "DDMMYYD", "DDMMYYD10",
@@ -25,37 +38,40 @@ const sas_date_formats = [
     "MMDDYYN6", "MMDDYYN8", "MMDDYYP", "MMDDYYP10", "MMDDYYS", "MMDDYYS10",
     "MONNAME", "MONTH", "WEEKDATX", "WEEKDAY", "QTR", "QTRR", "YEAR",
     "YYMMDDB", "YYMMDDD", "YYMMDDN", "YYMMDDP", "YYMMDDS", "DAY", "DOWNAME",
-    "E8601DA", "E8601DN"
+    "E8601DA"
 ]
-const sas_datetime_formats = [
-    "DATETIME", "DATETIME13", "DATETIME18", "DATETIME19",  "DATETIME20", "DATETIME21",
-    "DATETIME22", "TOD", "E8601DT", "E8601DX", "E8601DZ", "E8601LX",
-]
-const sas_time_formats = [
-    "TIME", "HHMM", "TIME20.3", "TIME20", "HOUR", "TIME5", "E8601LZ", "E8601TM",
-    "E8601TX", "E8601TZ"]
 
 const sas_dt_formats = Dict{String, Tuple{Union{DateTime,Date}, Period}}(
-    vcat(sas_date_formats .=> ((sas_epoch_date, Day(1)),),
-        sas_datetime_formats .=> ((sas_epoch_time, Second(1)),),
-        sas_time_formats .=> ((sas_epoch_time, Second(1)),))
+    vcat(sas_datetime_formats .=> ((sas_epoch_datetime, Second(1)),),
+        sas_date_formats .=> ((sas_epoch_date, Day(1)),))
 )
+
+function is_sas_time_format(format::AbstractString)
+    startswith(format, "TIME") && return true
+    # This may not be exhaustive?
+    return format in ("HHMM", "HOUR", "E8601TM")
+end
 
 # Reference: https://github.com/Roche/pyreadstat/blob/master/pyreadstat/_readstat_parser.pyx
 const spss_datetime_formats = [
     "DATETIME", "DATETIME8", "DATETIME17", "DATETIME20", "DATETIME23.2",
     "YMDHMS16", "YMDHMS19", "YMDHMS19.2", "YMDHMS20"
 ]
+# These date formats still internally record seconds just like datetime
 const spss_date_formats = [
     "DATE", "DATE8", "DATE11", "DATE12", "ADATE", "ADATE8", "ADATE10",
     "EDATE", "EDATE8", "EDATE10", "JDATE", "JDATE5", "JDATE7", "SDATE", "SDATE8", "SDATE10"
 ]
-const spss_time_formats = ["TIME", "DTIME", "TIME8", "TIME5", "TIME11.2"]
 
 const spss_dt_formats = Dict{String, Tuple{Union{DateTime,Date}, Period}}(
-    vcat(spss_datetime_formats, spss_date_formats, spss_time_formats) .=>
-        ((spss_epoch_time, Second(1)),)
+    vcat(spss_datetime_formats, spss_date_formats) .=> ((spss_epoch_datetime, Second(1)),)
 )
+
+function is_spss_time_format(format::AbstractString)
+    # TIME_LAPSE is for days
+    startswith(format, "TIME") && format!="TIME_LAPSE" && return true
+    return format == "DTIME"
+end
 
 const dt_formats = Dict{String, Dict}(
     ".dta" => stata_dt_formats,
@@ -67,18 +83,18 @@ const dt_formats = Dict{String, Dict}(
 
 const ext_date_epoch = Dict{String, Date}(
     ".dta" => stata_epoch_date,
-    ".sav" => spss_epoch_time,
-    ".por" => spss_epoch_time,
+    ".sav" => spss_epoch_datetime,
+    ".por" => spss_epoch_datetime,
     ".sas7bdat" => sas_epoch_date,
     ".xpt" => sas_epoch_date
 )
 
-const ext_time_epoch = Dict{String, DateTime}(
-    ".dta" => stata_epoch_time,
-    ".sav" => spss_epoch_time,
-    ".por" => spss_epoch_time,
-    ".sas7bdat" => sas_epoch_time,
-    ".xpt" => sas_epoch_time
+const ext_datetime_epoch = Dict{String, DateTime}(
+    ".dta" => stata_epoch_datetime,
+    ".sav" => spss_epoch_datetime,
+    ".por" => spss_epoch_datetime,
+    ".sas7bdat" => sas_epoch_datetime,
+    ".xpt" => sas_epoch_datetime
 )
 
 const ext_default_date_delta = Dict{String, Period}(
@@ -89,7 +105,7 @@ const ext_default_date_delta = Dict{String, Period}(
     ".xpt" => Day(1)
 )
 
-const ext_default_time_delta = Dict{String, Period}(
+const ext_default_datetime_delta = Dict{String, Period}(
     ".dta" => Millisecond(1),
     ".sav" => Second(1),
     ".por" => Second(1),
@@ -105,7 +121,7 @@ const ext_default_date_format = Dict{String, String}(
     ".xpt" => "DATE"
 )
 
-const ext_default_time_format = Dict{String, String}(
+const ext_default_datetime_format = Dict{String, String}(
     ".dta" => "%tc",
     ".sav" => "DATETIME",
     ".por" => "DATETIME",
@@ -178,3 +194,196 @@ num2datetime(col::AbstractVector, ndt::Num2DateTime) =
 datetime2num(col::AbstractVector, ndt::Num2DateTime) =
     mappedarray(DateTime2Num{typeof(ndt)}(ndt), ndt, col)
 
+_time2num(x::Time) = x.instant.value / 1e9
+_time2num(::Missing) = missing
+
+# Only used when writing to files
+time2num(col::AbstractVector) = mappedarray(_time2num, col)
+
+"""
+    HMS{T}
+
+A wrapped numeric value of type `T` representing the number of seconds
+printed in a time format `H:MM:SS.dd` on REPL.
+The value may represent either the duration of time elapsed or a time point in a day.
+
+`H` is either the number of hours elapsed or hours in a day.
+Unlike `Dates.Time`, `H` is allowed to be greater than 23
+because it may represent duration.
+`MM` is for minutes (00 to 59).
+`SS` is for seconds (00 to 59).
+`dd` is for decimal fractions of a second, rounded to the closest 1/100 second (00 to 99).
+
+Some basic operations are supported,
+including comparison and addition/subtraction.
+For more involved time operations,
+users are expected to convert an instance of `HMS` to a more specialized object.
+Conversion to `Dates.Time` is supported if `H` falls in 0 to 23.
+To retrieve the wrapped numeric value, call `unwrap`.
+
+# Examples
+```jldoctest
+julia> t1 = HMS(99999.99)
+27:46:39.99
+
+julia> t2 = HMS(-123.4567)
+-0:02:03.46
+
+julia> t1 < t2
+false
+
+julia> t1 + t2
+27:44:36.53
+
+julia> t1 - t2
+27:48:43.45
+
+julia> t3 = HMS(12345.6789)
+3:25:45.68
+
+julia> Time(t3)
+03:25:45.6789
+
+julia> unwrap(t3)
+12345.6789
+```
+"""
+struct HMS{T}
+    value::T
+    function HMS(value::T) where T<:Real
+        return new{T}(value)
+    end
+end
+
+"""
+    unwrap(x::HMS)
+
+Return the numeric value representing the number of seconds elapsed.
+"""
+unwrap(x::HMS) = x.value
+
+# Allow comparisons between HMS and numbers
+Base.:(==)(x::HMS, y::HMS) = x.value == y.value
+Base.isequal(x::HMS, y::HMS) = isequal(x.value, y.value)
+Base.:(<)(x::HMS, y::HMS) = x.value < y.value
+Base.isless(x::HMS, y::HMS) = isless(x.value, y.value)
+Base.isapprox(x::HMS, y::HMS; kwargs...) =
+    isapprox(x.value, y.value; kwargs...)
+
+Base.:(==)(x::HMS, y) = x.value == y
+Base.:(==)(x, y::HMS) = x == y.value
+Base.:(==)(::HMS, ::Missing) = missing
+Base.:(==)(::Missing, ::HMS) = missing
+
+Base.isequal(x::HMS, y) = isequal(x.value, y)
+Base.isequal(x, y::HMS) = isequal(x, y.value)
+Base.isequal(x::HMS, y::Missing) = isequal(x.value, y)
+Base.isequal(x::Missing, y::HMS) = isequal(x, y.value)
+Base.:(<)(x::HMS, y) = x.value < y
+Base.:(<)(x, y::HMS) = x < y.value
+Base.:(<)(x::HMS, y::Missing) = x.value < y
+Base.:(<)(x::Missing, y::HMS) = x < y.value
+Base.isless(x::HMS, y) = isless(x.value, y)
+Base.isless(x, y::HMS) = isless(x, y.value)
+Base.isless(x::HMS, y::Missing) = isless(x.value, y)
+Base.isless(x::Missing, y::HMS) = isless(x, y.value)
+Base.isapprox(x::HMS, y; kwargs...) = isapprox(x.value, y; kwargs...)
+Base.isapprox(x, y::HMS; kwargs...) = isapprox(x, y.value; kwargs...)
+Base.ismissing(x::HMS) = ismissing(x.value)
+
+Base.iszero(x::HMS) = iszero(x.value)
+Base.isnan(x::HMS) = isnan(x.value)
+Base.isinf(x::HMS) = isinf(x.value)
+Base.isfinite(x::HMS) = isfinite(x.value)
+
+Base.hash(x::HMS, h::UInt) = hash(x.value, h)
+
+Base.length(x::HMS) = length(x.value)
+
+Base.:(+)(x::HMS, y::HMS) = HMS(x.value + y.value)
+Base.:(+)(x::HMS, y::Real) = HMS(x.value + y)
+Base.:(+)(x::Real, y::HMS) = HMS(x + y.value)
+Base.:(+)(::HMS, ::Missing) = missing
+Base.:(+)(::Missing, ::HMS) = missing
+Base.:(-)(x::HMS, y::HMS) = HMS(x.value - y.value)
+Base.:(-)(x::HMS, y::Real) = HMS(x.value - y)
+Base.:(-)(x::Real, y::HMS) = HMS(x - y.value)
+Base.:(-)(::HMS, ::Missing) = missing
+Base.:(-)(::Missing, ::HMS) = missing
+Base.:(-)(x::HMS) = HMS(-x.value)
+Base.abs(x::HMS) = HMS(abs(x.value))
+
+# When the data represent time in a day
+function Time(t::HMS)
+    t.value < 0 && error("Time cannot be negative")
+    ns = round(Int, 1e9*t.value)
+    return Time(Nanosecond(ns))
+end
+
+function _parse_time(t::Real)
+    v = abs(t)
+    whole_sec = floor(Int, v)
+    hours, remainder = divrem(whole_sec, 3600)
+    minutes, seconds = divrem(remainder, 60)
+    return hours, minutes, seconds, v - whole_sec
+end
+
+function Base.show(io::IO, t::HMS)
+    H, M, S, d = _parse_time(t.value)
+    t.value < 0 && print(io, '-')
+    d = round(Int, 100 * d) # Only print 2 decimals
+    # H is intentionally not padded by 0 to hint the possibility of varying width
+    print(io, H, ':', lpad(M,2,'0'), ':', lpad(S,2,'0'), '.', lpad(d,2,'0'))
+end
+
+# This allows array show to align HMS by the first ':'
+function Base.alignment(io::IO, t::HMS)
+    s = sprint(show, t, context=Base.nocolor(io), sizehint=0)
+    i = findfirst(==(':'), s)
+    return textwidth(first(s, i-1)), textwidth(SubString(s, i))
+end
+
+struct HMSCol{T, A<:AbstractVector{T}} <: AbstractVector{HMS{T}}
+    a::A
+    function HMSCol(a::AbstractVector{T}) where T
+        nonmissingtype(T) <: Real ||
+            error("Unsupported element type of $(T)")
+        return new{T, typeof(a)}(a)
+    end
+end
+
+"""
+    refarray(x::HMSCol)
+    refarray(x::SubArray{<:Any, <:Any, <:HMSCol})
+    refarray(x::Base.ReshapedArray{<:Any, <:Any, <:HMSCol})
+    refarray(x::SubArray{<:Any, <:Any, <:Base.ReshapedArray{<:Any, <:Any, <:HMSCol}})
+
+Return the array of values underlying a [`HMSCol`](@ref).
+"""
+refarray(x::HMSCol) = x.a
+refarray(x::SubArray{<:Any, <:Any, <:HMSCol}) =
+    view(parent(x).a, x.indices...)
+refarray(x::Base.ReshapedArray{<:Any, <:Any, <:HMSCol}) =
+    reshape(parent(x).a, size(x))
+refarray(x::SubArray{<:Any, <:Any, <:Base.ReshapedArray{<:Any, <:Any, <:HMSCol}}) =
+    view(reshape(parent(parent(x)).a, size(parent(x))), x.indices...)
+
+Base.size(col::HMSCol) = size(refarray(col))
+Base.IndexStyle(::Type{<:HMSCol{T,A}}) where {T,A} = IndexStyle(A)
+
+Base.@propagate_inbounds Base.getindex(col::HMSCol, i::Int) =
+    (v = refarray(col)[i]; ismissing(v) ? v : HMS(v))
+Base.@propagate_inbounds Base.setindex!(col::HMSCol, v, i::Int) =
+    (refarray(col)[i] = unwrap(v); col)
+
+Base.similar(col::HMSCol, ::Type{<:HMS{T}}, dims::Dims) where T =
+    HMSCol(similar(refarray(col), T, dims))
+
+# Define abbreviated element type name for printing with PrettyTables.jl
+@static if isdefined(PrettyTables, :compact_type_str) # PrettyTables < v3
+    PrettyTables.compact_type_str(::Type{HMS{V}}) where V =
+        string("HMS{", PrettyTables.compact_type_str(V), "}")
+elseif isdefined(PrettyTables, :_compact_type_str) # PrettyTables v3
+    PrettyTables._compact_type_str(::Type{HMS{V}}) where V =
+        string("HMS{", PrettyTables._compact_type_str(V), "}")
+end

--- a/src/table.jl
+++ b/src/table.jl
@@ -301,9 +301,15 @@ Base.@propagate_inbounds function Tables.getcolumn(tb::ReadStatTable, i::Int)
     # Construct MappedArray if format is a recognized date/time format
     format = _colmeta(tb, i, :format)
     ext = _meta(tb).file_ext
-    ext == ".dta" && (format = first(format, 3))
+    isdta = ext == ".dta"
+    isdta && (format = first(format, 3)) # Ignore detail code that only affects display
     dtpara = get(dt_formats[ext], format, nothing)
-    return dtpara === nothing ? col : num2datetime(col, Num2DateTime(dtpara...))
+    dtpara === nothing || return num2datetime(col, Num2DateTime(dtpara...))
+    isdta && return col
+    # Handle pure time types in SAS/SPSS
+    istime = ext ∈ (".sav", ".por") ? is_spss_time_format(format) :
+        is_sas_time_format(format)
+    return istime ? HMSCol(col) : col
 end
 
 Base.@propagate_inbounds Tables.getcolumn(tb::ReadStatTable, n::Symbol) =

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -147,34 +147,68 @@ function ReadStatTable(table, ext::AbstractString;
                 colmeta.format[i] = format = mformat
             end
         end
+        isdta = ext == ".dta"
+        T = nonmissingtype(eltype(col))
+
         # Lazily convert any Date/DateTime column
-        if nonmissingtype(eltype(col)) ∈ (Date, DateTime) # Avoid Missing column
+        if T ∈ (Date, DateTime) # Avoid Missing column
             copycols || error("to write tables with date/time columns, copycols must be true")
-            ext == ".dta" && (format = first(format, 3))
+            isdta && (format = first(format, 3))
             dtpara = get(dt_formats[ext], format, nothing)
-            if dtpara === nothing
+            if dtpara === nothing # Use defaults when column format is not specified
                 if Date <: eltype(col)
                     epoch = ext_date_epoch[ext]
                     delta = ext_default_date_delta[ext]
                     colmeta.format[i] = ext_default_date_format[ext]
                 else
-                    epoch = ext_time_epoch[ext]
-                    delta = ext_default_time_delta[ext]
-                    colmeta.format[i] = ext_default_time_format[ext]
+                    epoch = ext_datetime_epoch[ext]
+                    delta = ext_default_datetime_delta[ext]
+                    colmeta.format[i] = ext_default_datetime_format[ext]
                 end
             else
                 epoch, delta = dtpara
-                nonmissingtype(eltype(col)) == typeof(epoch) ||
+                T == typeof(epoch) ||
                     error("a date/datetime column must have a date/datetime format")
             end
             col = datetime2num(col, Num2DateTime(epoch, delta))
         end
+
+        # Handle pure time columns
+        needtimeformat = false
+        if T == Time
+            isdta && error("Julia Time is not allowed when writing .dta file due to ambiguity; please convert to either DateTime or a numeric type")
+            needtimeformat = true
+            col = time2num(col)
+        elseif T <: HMS
+            # For Stata .dta, do not convert to %tc and just write number of seconds
+            # (No reliable way to tell whether the epoch date is actual data or not in ouput)
+            needtimeformat = !isdta
+            # Expect Float64 for element type but do not enforce the conversion here?
+            col = col isa HMSCol ? refarray(col) : unwrap.(col)
+            if isdta && format == "%tc"
+                error("HMS column with format %tc is not allowed for Stata .dta file")
+            end
+        end
+        if needtimeformat # Should never be true for .dta
+            if format != ""
+                istime = ext ∈ (".sav", ".por") ? is_spss_time_format(format) :
+                    is_sas_time_format(format)
+                if !istime
+                    @warn "Encountered invalid time format $format for $(names[i]); have changed to TIME automatically"
+                    colmeta.format[i] = "TIME"
+                end
+            else
+                colmeta.format[i] = "TIME"
+            end
+        end
+
+        T = nonmissingtype(eltype(col)) # col may have been redefined
         if col isa LabeledArrOrSubOrReshape || refpool(col) !== nothing && refpoolaslabel
             type = rstype(nonmissingtype(eltype(refarray(col))))
         elseif eltype(col) == Missing # Will write empty strings
             type = READSTAT_TYPE_STRING
         else
-            type = rstype(nonmissingtype(eltype(col)))
+            type = rstype(T)
         end
         colmeta.type[i] = colmetadata(table, i, "type", type)
         lblname = colmetadata(table, i, "vallabel", Symbol())
@@ -216,7 +250,6 @@ function ReadStatTable(table, ext::AbstractString;
                     # Cannot turn "" into String1
                     tarcol = fill("", M)
                 else
-                    T = nonmissingtype(eltype(col))
                     if T in (String3, String7, String15, String31,
                             String63, String127, String255)
                         tarcol = Vector{T}(undef, M)
@@ -228,7 +261,6 @@ function ReadStatTable(table, ext::AbstractString;
             if col isa LabeledArrOrSubOrReshape || refpool(col) !== nothing && refpoolaslabel
                 copyto!(tarcol, refarray(col))
             elseif eltype(col) != Missing
-                T = nonmissingtype(eltype(col))
                 if T <: InlineString || T == String
                     # missing is replaced by "" for string columns
                     tarcol .= T.(coalesce.(col, ""))
@@ -282,6 +314,22 @@ function ReadStatTable(table::ReadStatTable, ext::AbstractString;
         end
     end
     return table
+end
+
+function _check_varname(tb::ReadStatTable, ext)
+    # Make violations to .por var name restrictions more obvious to users
+    if ext == ".por"
+        for (i, n) in enumerate(_names(tb))
+            n = string(n)
+            if length(n) > 8
+                error(".por file limits each variable name to 8 characters; encountered $n")
+            end
+            if any(islowercase, n)
+                @warn ".por file does not allow lowercase letter in variable names; have converted to uppercase automatically"
+                _names(tb)[i] = Symbol(uppercase.(n))
+            end
+        end
+    end
 end
 
 """
@@ -338,6 +386,8 @@ function writestat(filepath, table; ext = lowercase(splitext(filepath)[2]), kwar
     write_ext = get(ext2writer, ext, nothing)
     write_ext === nothing && throw(ArgumentError("file extension $ext is not supported"))
     tb = ReadStatTable(table, ext; kwargs...)
+    # .por has additional restrictions on var names
+    _check_varname(tb, ext)
     io = open(filepath, "w")
     _write(io, ext, write_ext, tb)
     return tb

--- a/test/datetime.jl
+++ b/test/datetime.jl
@@ -78,5 +78,5 @@ end
     @test size(x1) == size(x)
 
     # HMSCol copy is still HMSCol
-    @test copy(x) == typeof(x)
+    @test typeof(copy(x)) == typeof(x)
 end

--- a/test/datetime.jl
+++ b/test/datetime.jl
@@ -64,8 +64,6 @@ end
     x = HMSCol([1e6, -1.2, 123.456, missing])
     @test refarray(x) === x.a
     @test refarray(view(x,1:2)) == view(x.a,1:2)
-    @test isequal(refarray(reshape(x,2,2)), reshape(x.a,2,2))
-    @test refarray(view(reshape(x,2,2),1:2)) == view(reshape(x.a,2,2),1:2)
 
     @test size(x) == (4,)
     @test IndexStyle(x) == IndexStyle(x.a)
@@ -78,4 +76,7 @@ end
     x1 = similar(x)
     @test typeof(x1) == typeof(x)
     @test size(x1) == size(x)
+
+    # HMSCol copy is still HMSCol
+    @test copy(x) == typeof(x)
 end

--- a/test/datetime.jl
+++ b/test/datetime.jl
@@ -1,0 +1,81 @@
+@testset "HMS" begin
+    t0 = HMS(0)
+    t1 = HMS(100.0)
+    t2 = HMS(200)
+    t3 = HMS(100)
+
+    @test unwrap(t1) === 100.0
+    @test t1 == t3
+    @test t1 == 100
+    @test 100 == t1
+    @test ismissing(t1 == missing)
+    @test ismissing(missing == t1)
+    @test isequal(t1, t3)
+    @test isequal(t1, 100)
+    @test isequal(100, t1)
+    @test !isequal(t1, missing)
+    @test !isequal(missing, t1)
+    @test t1 < t2
+    @test t1 < 200
+    @test 0 < t1
+    @test ismissing(t1 < missing)
+    @test ismissing(missing < t1)
+    @test isless(t1, t2)
+    @test isless(t1, 200)
+    @test isless(0, t1)
+    @test isless(t1, missing)
+    @test !isless(missing, t1)
+    @test isapprox(t1, t3)
+    @test isapprox(t1, 100)
+    @test isapprox(100, t1)
+    @test !ismissing(t1)
+
+    @test iszero(t0)
+    @test isnan(HMS(NaN))
+    @test isinf(HMS(Inf))
+    @test isfinite(t1)
+
+    @test hash(t1) == hash(t1.value)
+    @test length(t1) == 1
+
+    @test t1 + t2 == HMS(300)
+    @test t1 + 100 == HMS(200)
+    @test 100 + t1 == 200
+    @test ismissing(t1 + missing)
+    @test ismissing(missing + t1)
+    @test t1 - t2 == HMS(-100)
+    @test t1 - 100 == 0
+    @test 100 - t1 == HMS(0)
+    @test ismissing(t1 - missing)
+    @test ismissing(missing - t1)
+    @test -t1 == HMS(-100)
+    @test abs(HMS(-10)) == 10
+
+    @test Time(HMS(123.456)) == Time("00:02:03.456")
+
+    @test sprint(show, HMS(123456.789)) == "34:17:36.79"
+    @test sprint(show, MIME("text/plain"), [HMS(1e6),HMS(-1.2)]) == """
+        2-element Vector{HMS{Float64}}:
+         277:46:40.00
+          -0:00:01.20"""
+end
+
+@testset "HMSCol" begin
+    x = HMSCol([1e6, -1.2, 123.456, missing])
+    @test refarray(x) === x.a
+    @test refarray(view(x,1:2)) == view(x.a,1:2)
+    @test isequal(refarray(reshape(x,2,2)), reshape(x.a,2,2))
+    @test refarray(view(reshape(x,2,2),1:2)) == view(reshape(x.a,2,2),1:2)
+
+    @test size(x) == (4,)
+    @test IndexStyle(x) == IndexStyle(x.a)
+    @test x[1] == HMS(1e6)
+    @test ismissing(x[4])
+    x[1] = HMS(123)
+    @test x[1] == 123
+    x[1] = 456
+    @test x[1] == HMS(456)
+    x1 = similar(x)
+    @test typeof(x1) == typeof(x)
+    @test size(x1) == size(x)
+end

--- a/test/readstat.jl
+++ b/test/readstat.jl
@@ -273,14 +273,14 @@ end
     d = readstat(sav)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │ mychar    mynum               mydate                dtime            mylabl             myord               mytime
-             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}            DateTime?
-        ─────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low  1582-10-14T10:10:10
-           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium  1582-10-14T23:10:10
-           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high  1582-10-14T00:00:00
-           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low  1582-10-14T16:10:10
-           5 │      e   1000.3              missing              missing              Male               low              missing"""
+         Row │ mychar    mynum               mydate                dtime            mylabl             myord         mytime
+             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}  HMS{Float64?}
+        ─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────
+           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low    10:10:10.00
+           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium    23:10:10.00
+           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high     0:00:00.00
+           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low    16:10:10.00
+           5 │      e   1000.3              missing              missing              Male               low        missing"""
 
     d = readstat(sav, ntasks=3)
     @test d isa ReadStatTable{ChainedReadStatColumns}
@@ -315,14 +315,14 @@ end
     d = readstat(por)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │ MYCHAR    MYNUM               MYDATE                DTIME            MYLABL             MYORD               MYTIME
-             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}            DateTime?
-        ─────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low  1582-10-14T10:10:10
-           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium  1582-10-14T23:10:10
-           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high  1582-10-14T00:00:00
-           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low  1582-10-14T16:10:10
-           5 │      e   1000.3              missing              missing              Male               low              missing"""
+         Row │ MYCHAR    MYNUM               MYDATE                DTIME            MYLABL             MYORD         MYTIME
+             │ String  Float64            DateTime?            DateTime?  Labeled{Float64}  Labeled{Float64}  HMS{Float64?}
+        ─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────
+           1 │      a      1.1  2018-05-06T00:00:00  2018-05-06T10:10:10              Male               low    10:10:10.00
+           2 │      b      1.2  1880-05-06T00:00:00  1880-05-06T10:10:10            Female            medium    23:10:10.00
+           3 │      c  -1000.3  1960-01-01T00:00:00  1960-01-01T00:00:00              Male              high     0:00:00.00
+           4 │      d     -1.4  1583-01-01T00:00:00  1583-01-01T00:00:00            Female               low    16:10:10.00
+           5 │      e   1000.3              missing              missing              Male               low        missing"""
 
     d = readstat(por, ntasks=3)
     @test d isa ReadStatTable{ReadStatColumns}
@@ -357,14 +357,14 @@ end
     d = readstat(sas7)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │  mychar    mynum      mydate                dtime   mylabl    myord               mytime
-             │ String3  Float64       Date?            DateTime?  Float64  Float64            DateTime?
-        ─────┼──────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing      1.0      1.0              missing"""
+         Row │  mychar    mynum      mydate                dtime   mylabl    myord         mytime
+             │ String3  Float64       Date?            DateTime?  Float64  Float64  HMS{Float64?}
+        ─────┼────────────────────────────────────────────────────────────────────────────────────
+           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0    10:10:10.00
+           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0    23:10:10.00
+           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0     0:00:00.00
+           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0    16:10:10.00
+           5 │       e   1000.3     missing              missing      1.0      1.0        missing"""
 
     d = readstat(sas7, ntasks=3)
     @test d isa ReadStatTable{ChainedReadStatColumns}
@@ -397,14 +397,14 @@ end
     d = readstat(xpt)
     @test sprint(show, MIME("text/plain"), d, context=:displaysize=>(15,150)) == """
         5×7 ReadStatTable:
-         Row │  MYCHAR    MYNUM      MYDATE                DTIME   MYLABL    MYORD               MYTIME
-             │ String3  Float64       Date?            DateTime?  Float64  Float64            DateTime?
-        ─────┼──────────────────────────────────────────────────────────────────────────────────────────
-           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0  1960-01-01T10:10:10
-           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0  1960-01-01T23:10:10
-           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0  1960-01-01T00:00:00
-           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0  1960-01-01T16:10:10
-           5 │       e   1000.3     missing              missing      1.0      1.0              missing"""
+         Row │  MYCHAR    MYNUM      MYDATE                DTIME   MYLABL    MYORD         MYTIME
+             │ String3  Float64       Date?            DateTime?  Float64  Float64  HMS{Float64?}
+        ─────┼────────────────────────────────────────────────────────────────────────────────────
+           1 │       a      1.1  2018-05-06  2018-05-06T10:10:10      1.0      1.0    10:10:10.00
+           2 │       b      1.2  1880-05-06  1880-05-06T10:10:10      2.0      2.0    23:10:10.00
+           3 │       c  -1000.3  1960-01-01  1960-01-01T00:00:00      1.0      3.0     0:00:00.00
+           4 │       d     -1.4  1583-01-01  1583-01-01T00:00:00      2.0      1.0    16:10:10.00
+           5 │       e   1000.3     missing              missing      1.0      1.0        missing"""
 
     d = readstat(xpt, ntasks=3)
     @test d isa ReadStatTable{ReadStatColumns}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ using Tables: getcolumn
 
 const tests = [
     "LabeledArrays",
+    "datetime",
     "columns",
     "table",
     "readstat",

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -74,6 +74,43 @@ end
     @test isequal(tb.date.data, [missing, 0, 0, 0, 0, 0, 0, 1, 1, 2, 2, -1, -1, -1, -2])
 end
 
+@testset "writestat time" begin
+    df1 = DataFrame((TIME1 = [Time(1), Time(2,3), missing],
+        HMS1 = HMSCol([1.5, -2.3, missing]),
+        HMS2 = [HMS(1), HMS(-2), missing]))
+    for ext in [".por", ".sav", ".sas7bdat", ".xpt"]
+        outfile = "$(@__DIR__)/../data/test_time$(ext)"
+        tb1 = ReadStatTable(df1, ext)
+        for k in 1:3
+            @test tb1[k] isa HMSCol
+        end
+        @test eltype(refarray(tb1[1])) == Union{Float64,Missing}
+        @test isequal(refarray(tb1[1]), [3600.0, 7380.0, missing])
+        @test eltype(refarray(tb1[2])) == Union{Float64,Missing}
+        @test isequal(refarray(tb1[2]), [1.5, -2.3, missing])
+        @test eltype(refarray(tb1[3])) == Union{Int32,Missing}
+        @test isequal(refarray(tb1[3]), [1, -2, missing])
+        writestat(outfile, tb1)
+
+        colmetadata!(df1, :TIME1, "format", "WRONG"; style=:note)
+        colmetadata!(df1, :HMS1, "format", "TIME9"; style=:note)
+        tb1 = writestat(outfile, df1)
+        @test colmetadata(tb1, :TIME1, "format") == "TIME"
+        @test colmetadata(tb1, :HMS1, "format") == "TIME9"
+    end
+
+    outfile = "$(@__DIR__)/../data/test_time.dta"
+    @test_throws ErrorException ReadStatTable(df1, ".dta")
+    df2 = df1[!,2:3]
+    tb2 = ReadStatTable(df2, ".dta")
+    @test eltype(tb2[1]) == Union{Float64,Missing}
+    @test isequal(tb2[1], refarray(df2.HMS1))
+    @test eltype(tb2[2]) == Union{Int32,Missing}
+    @test isequal(tb2[2], refarray(df2.HMS2))
+    colmetadata!(df2, :HMS1, "format", "%tc"; style=:note)
+    @test_throws ErrorException ReadStatTable(df2, ".dta")
+end
+
 @testset "writestat string" begin
     outfile = "$(@__DIR__)/../data/test_string.dta"
     types = [String, String3, String7, String15, String31,
@@ -230,4 +267,15 @@ extensions = ["dta", "por", "sav", "sas7bdat", "xpt"]
     r = readstat(datetimefile)
     @test r.DATE == datetime.DATE
     @test r.TIME == datetime.TIME
+end
+
+@testset "writestat por" begin
+    # Check invalid var names (only matters for .por)
+    df1 = DataFrame((a=[1], aBc2=[2]))
+    outfile = "$(@__DIR__)/../data/test_por_name.por"
+    tb1 = writestat(outfile, df1)
+    @test columnnames(tb1) == [:A, :ABC2]
+
+    df2 = DataFrame((abcdefghi=[0],))
+    @test_throws ErrorException writestat(outfile, df2)
 end


### PR DESCRIPTION
The read/write processes now handle time/duration variables differently from date/datetime variables. This is particularly relevant to SAS and SPSS.

In the earlier versions, there is no such a notion of pure time variables. That is, a time-related variable always incorporates information on dates. A consequence of doing so is that it is hard to hint the irrelevance of dates when what matters is only the time within a day or duration (possibly going beyond 24 hours). For SAS/SPSS where formats dedicated to pure time variables are available, the use of a date epoch introduces redundant date information.

To address such discrepancies, mostly for SAS/SPSS, pure time/duration variables are now simply represented as the number of seconds (without shifting from an epoch datetime). However, for displaying the data to human, a custom type `HMS` (and related `HMSCol`) is introduced. `HMS` is a wrapper around the number of seconds that allows printing the time in the format of `H:MM:SS.dd` lazily without modifying the original data. It is up to the users to determine how they want to proceed further with such pure time/duration variables.

Note: Julia `Dates.Time` strictly requires time of a day, which is different from the time variables in SAS/SPSS.

This supersedes #72 and closes #68.