### PR TITLE
Set default format for SPSS string variables based on max string length

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -118,6 +118,15 @@ function _write(io::IOStream, ext, write_ext, tb)
             var = add_variable(writer, name, type, width)
             variable_set_label(var, colmeta.label[i])
             format = colmeta.format[i]
+            if format == ""
+                # This enforces a default format based on storage width
+                if ext ∈ (".por", ".sav") && type == READSTAT_TYPE_STRING
+                    format = string("A", width)
+                    variable_set_format(var, format)
+                end
+            else
+                variable_set_format(var, format)
+            end
             format == "" || variable_set_format(var, format)
             label_set = get(label_sets, colmeta.vallabel[i], nothing)
             label_set === nothing || variable_set_label_set(var, label_set)

--- a/src/writestat.jl
+++ b/src/writestat.jl
@@ -25,12 +25,12 @@ const default_file_format_version = Dict{String, Int}(
 )
 
 # Accepted maximum length for strings varies by the file format and version
-function _readstat_string_width(col)
+function _readstat_string_width(col, scaninlinestring)
     # Allow LabeledArray with string/char values
     col = eltype(col) <: LabeledValue ? refarray(col) : col
     if eltype(col) == Missing
         return Csize_t(1)
-    elseif nonmissingtype(eltype(col)) <: InlineString
+    elseif !scaninlinestring && nonmissingtype(eltype(col)) <: InlineString
         return Csize_t(sizeof(eltype(col))-1)
     elseif nonmissingtype(eltype(col)) == Char
         return Csize_t(1)
@@ -93,6 +93,7 @@ A column with element type `Missing` is treated as a column with empty strings.
 - `meta::ReadStatMeta = ReadStatMeta()`: file-level metadata.
 - `colmeta::ColMetaVec = ReadStatColMetaVec()`: variable-level metadata stored in a `StructArray` of `ReadStatColMeta`s; values are always overwritten.
 - `varformat::Union{Dict{Symbol,String}, Nothing} = nothing`: specify variable-level format for certain variables with the key being the variable name (as `Symbol`) and value being the format string.
+- `scaninlinestring = true`: check the actual maximum length of any inline string column instead of using the maximum allowed by the string type.
 - `styles::Dict{Symbol, Symbol} = _default_metastyles()`: metadata styles.
 - `maxdispwidth::Integer = 60`: maximum `display_width` set for any variable.
 """
@@ -104,6 +105,7 @@ function ReadStatTable(table, ext::AbstractString;
         meta::ReadStatMeta = ReadStatMeta(),
         colmeta::ColMetaVec = ReadStatColMetaVec(),
         varformat::Union{Dict{Symbol,String}, Nothing} = nothing,
+        scaninlinestring::Bool = true,
         styles::Dict{Symbol, Symbol} = _default_metastyles(),
         maxdispwidth::Integer = 60,
         kwargs...)
@@ -218,7 +220,7 @@ function ReadStatTable(table, ext::AbstractString;
         # type may have been modified based on refarray
         type = colmeta.type[i]
         if type === READSTAT_TYPE_STRING
-            width = _readstat_string_width(col)
+            width = _readstat_string_width(col, scaninlinestring)
         elseif type === READSTAT_TYPE_DOUBLE
             # Only needed for .xpt files
             width = Csize_t(8)
@@ -290,9 +292,10 @@ for a supported file format with extension `ext`.
 
 # Keywords
 - `update_width::Bool = true`: determine the storage width for each string variable by checking the actual data columns instead of any existing metadata value.
+- `scaninlinestring = true`: check the actual maximum length of any inline string column instead of using the maximum allowed by the string type.
 """
 function ReadStatTable(table::ReadStatTable, ext::AbstractString;
-        update_width::Bool = true, kwargs...)
+        update_width::Bool = true, scaninlinestring = true, kwargs...)
     meta = _meta(table)
     meta.row_count = nrow(table)
     meta.var_count = ncol(table)
@@ -312,7 +315,7 @@ function ReadStatTable(table::ReadStatTable, ext::AbstractString;
         if update_width
             type = colmeta.type[i]
             if type === READSTAT_TYPE_STRING
-                colmeta.storage_width[i] = _readstat_string_width(col)
+                colmeta.storage_width[i] = _readstat_string_width(col, scaninlinestring)
             elseif type === READSTAT_TYPE_DOUBLE
                 # Only needed for .xpt files
                 colmeta.storage_width[i] = Csize_t(8)

--- a/test/writestat.jl
+++ b/test/writestat.jl
@@ -118,7 +118,7 @@ end
     cols = [Symbol(:col, i) => T[T("a")] for (i, T) in enumerate(types)]
     df = DataFrame((; cols...))
     df[!,:col0] .= 'a'
-    tb = writestat(outfile, df)
+    tb = writestat(outfile, df; scaninlinestring=false)
     push!(types, String)
     for (i, col) in enumerate(tb)
         @test eltype(col) == types[i]
@@ -132,7 +132,7 @@ end
     for col in eachcol(df)
         push!(col, missing)
     end
-    tb = writestat(outfile, df)
+    tb = writestat(outfile, df; scaninlinestring=false)
     push!(types, String)
     for (i, col) in enumerate(tb)
         @test eltype(col) == types[i]
@@ -198,10 +198,15 @@ end
     tb = writestat("$(@__DIR__)/../data/write_stringtypes.dta", strtype)
     @test isequal(tb, strtype)
     @test Int.(colmetavalues(tb, :storage_width)) ==
+        [1, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 255, 256]
+    tb = writestat("$(@__DIR__)/../data/write_stringtypes.dta", strtype;
+        scaninlinestring=false)
+    @test isequal(tb, strtype)
+    @test Int.(colmetavalues(tb, :storage_width)) ==
         [3, 3, 7, 7, 15, 15, 31, 31, 32, 63, 64, 127, 128, 255, 256]
     df = DataFrame(strtype)
     outfile = "$(@__DIR__)/../data/write_df_stringtypes.dta"
-    tb2 = writestat(outfile, df)
+    tb2 = writestat(outfile, df; scaninlinestring=false)
     # PooledArray is treated as LabeledArray
     @test all(colmetavalues(tb2, :type)[1:10].==READSTAT_TYPE_STRING)
     @test all(colmetavalues(tb2, :type)[11:15].==READSTAT_TYPE_INT32)
@@ -296,8 +301,10 @@ end
         @test tb.LBLSTR == df2.LBLSTR
         @test tb.LBLSTR3 isa typeof(df2.LBLSTR)
         @test tb.LBLSTR3 == df2.LBLSTR
+        @test colmetadata(tb, :LBLSTR3, "format") == "A1"
         @test tb.LBLCHAR isa typeof(df2.LBLSTR)
         @test tb.LBLCHAR == df2.LBLSTR
+        @test colmetadata(tb, :LBLCHAR, "format") == "A1"
         df2[!,:LBLWRONG] = LabeledArray([Time(1)],
             Dict{Union{Time,Char},String}(Time(1)=>"A"))
         @test_throws ErrorException writestat(outfile1, df2)


### PR DESCRIPTION
SPSS string variable formats contain the display length that is now determined based on the maximum string length of the data, instead of some fallback rules of `libreadstat`.

Closes #73.